### PR TITLE
fix(ios): evict stale FetchCache entries on barrier queue

### DIFF
--- a/packages/react-native-nitro-fetch/ios/FetchCache.swift
+++ b/packages/react-native-nitro-fetch/ios/FetchCache.swift
@@ -40,13 +40,24 @@ final class FetchCache {
 
   static func getResultIfFresh(_ key: String, maxAgeMs: Int64) -> NitroResponse? {
     var out: NitroResponse?
+    var shouldEvict = false
     queue.sync {
       if let entry = results[key] {
         let age = Int64(Date().timeIntervalSince1970 * 1000) - entry.timestampMs
         if age <= maxAgeMs {
           out = entry.response
         } else {
-          results.removeValue(forKey: key)
+          shouldEvict = true
+        }
+      }
+    }
+    if shouldEvict {
+      queue.async(flags: .barrier) {
+        if let entry = results[key] {
+          let age = Int64(Date().timeIntervalSince1970 * 1000) - entry.timestampMs
+          if age > maxAgeMs {
+            results.removeValue(forKey: key)
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
**Compared to `main`:** **`FetchCache.getResultIfFresh`** no longer removes stale cache entries during a concurrent read (`sync`). Eviction runs on a **barrier** async block with a **second age check** so readers do not mutate `results` in the read path and races with refresh are reduced.

## What changes
- Stale entries: mark for eviction during the read pass; delete inside `queue.async(flags: .barrier)` only if still stale.

## How to verify
- Exercise concurrent prefetch cache reads / TTL expiry (existing app or test harness).