### PR TITLE
feat: Allow pods to be installed on tvOS

### DIFF
--- a/packages/react-native-nitro-fetch/NitroFetch.podspec
+++ b/packages/react-native-nitro-fetch/NitroFetch.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported }
   s.source       = { :git => "http://google.com.git", :tag => "#{s.version}" }
 
 

--- a/packages/react-native-nitro-text-decoder/NitroTextDecoder.podspec
+++ b/packages/react-native-nitro-text-decoder/NitroTextDecoder.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [

--- a/packages/react-native-nitro-websockets/NitroFetchWebsockets.podspec
+++ b/packages/react-native-nitro-websockets/NitroFetchWebsockets.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [


### PR DESCRIPTION
## Background
My team is using NitroFetch for a project that includes tvOS, and I am trying to add websockets to the project.

I was getting this error:
> if you use nitrogen, make sure your `nitro.json` contains `NitroTextEncoding` on this platform

Which after some debugging appeared to be incorrect. Eventually, I tried patching the `tvos` platform into the podspec for each package, and it appears to fix the issue

## Summary

Just adding tvos to the podspec files, so that the pods can be correctly installed on tvos.
