### PR TITLE
Refactor global-replace.md for formatting consistency

### DIFF
--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -1,90 +1,171 @@
----
-id: global-replace
-title: Global Replace
-sidebar_position: 1
----
+  ---
+  id: global-replace
+  title: Global Replace
+  sidebar_position: 1
+  ---
 
-# Global Replace
+  # Global Replace
 
-By default you import `fetch` explicitly from `react-native-nitro-fetch` at each call site. If you prefer a drop-in replacement so that **all** `fetch()` calls in your app (and third-party libraries) go through Nitro, you can install it globally.
+  By default you import `fetch` explicitly from `react-native-nitro-fetch` at each call site. If
+  you prefer a drop-in replacement so that **all** `fetch()` calls in your app (and third-party
+  libraries) go through Nitro, you can install it globally.
 
-## Setup
+  ## Setup
 
-Add this at the **very top** of your entry file (before any other imports):
+  Add this at the **very top** of your entry file (before any other imports):
 
-```ts
-// index.js or App.tsx — must be the first import
-import { fetch, Headers, Request, Response } from 'react-native-nitro-fetch';
+  ```ts
+  // index.js or App.tsx — must be the first import
+  import { fetch, Headers, Request, Response } from 'react-native-nitro-fetch';
 
-globalThis.fetch = fetch;
-globalThis.Headers = Headers;
-globalThis.Request = Request;
-globalThis.Response = Response;
-```
+  globalThis.fetch = fetch;
+  globalThis.Headers = Headers;
+  globalThis.Request = Request;
+  globalThis.Response = Response;
+  ```
 
-That's it — every `fetch()` call in the process now uses the Nitro implementation.
+  That's it — every `fetch()` call in the process now uses the Nitro implementation.
 
-## WebSocket
+  ## WebSocket
 
-The same pattern works for the WebSocket package:
+  The same pattern works for the WebSocket package:
 
-```ts
-import { NitroWebSocket } from 'react-native-nitro-websockets';
+  ```ts
+  import { NitroWebSocket } from 'react-native-nitro-websockets';
 
-globalThis.WebSocket = NitroWebSocket;
-```
+  globalThis.WebSocket = NitroWebSocket;
+  ```
 
-:::tip
-Many WebSocket libraries (Socket.IO, Centrifuge) accept a `WebSocket` constructor option — passing `NitroWebSocket` there avoids touching the global entirely:
+  :::tip
+  Many WebSocket libraries (Socket.IO, Centrifuge) accept a `WebSocket` constructor option —
+  passing `NitroWebSocket` there avoids touching the global entirely:
 
-```ts
-import { io } from 'socket.io-client';
-import { NitroWebSocket } from 'react-native-nitro-websockets';
+  ```ts
+  import { io } from 'socket.io-client';
+  import { NitroWebSocket } from 'react-native-nitro-websockets';
 
-const socket = io('https://example.com', {
-  transports: ['websocket'],
-  WebSocket: NitroWebSocket,
-});
-```
-:::
-
-## Axios
-
-If you use [axios](https://axios-http.com), you can route all requests through Nitro via a custom adapter:
-
-```ts
-import axios, { AxiosAdapter, AxiosHeaders } from 'axios';
-import { fetch } from 'react-native-nitro-fetch';
-
-const nitroAxiosAdapter: AxiosAdapter = async (config) => {
-  const url = buildURL(config);
-  const res = await fetch(url, {
-    method: (config.method ?? 'get').toUpperCase(),
-    headers: AxiosHeaders.from(config.headers as any).toJSON() as Record<string, string>,
-    body: config.data,
-    signal: config.signal,
+  const socket = io('https://example.com', {
+    transports: ['websocket'],
+    WebSocket: NitroWebSocket,
   });
+  ```
+  :::
 
-  const headers = new AxiosHeaders();
-  res.headers.forEach((v, k) => headers.set(k, v));
-  const data = config.responseType === 'arraybuffer' ? await res.arrayBuffer()
-    : config.responseType === 'blob' ? await res.blob()
-    : config.responseType === 'text' ? await res.text()
-    : await res.json().catch(() => null);
+  ## Axios
 
-  return { data, status: res.status, statusText: res.statusText, headers, config, request: null };
-};
+  If you use [axios](https://axios-http.com), you can route all requests through Nitro via a custom
+  adapter.
 
-function buildURL(config: any): string {
-  let url = config.url ?? '';
-  if (config.baseURL && !/^https?:\/\//i.test(url))
-    url = config.baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
-  if (config.params) {
-    const qs = new URLSearchParams(config.params).toString();
-    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+  :::warning
+  A custom adapter is responsible for two things that axios normally does for you. Skipping either
+  one produces bugs that only surface in edge cases — the happy path looks fine, so they tend to
+  reach production:
+
+  1. **Param serialization.** Don't pass `config.params` straight into `URLSearchParams` — it
+  coerces every value with `String()`, so `undefined` becomes the literal `"undefined"`, arrays are
+  comma-joined instead of repeated as `key[]`, and `Date` objects become `"Tue May 29 2026…"`
+  instead of ISO. Axios's default serializer drops nullish values and expands arrays/Dates;
+  replicate that.
+  2. **Status handling.** Axios adapters must reject on non-2xx responses (this is what `settle()`
+  does internally). If you just return the response, every `4xx`/`5xx` resolves as a *success*,
+  which silently disables `try/catch`, status checks, and response error interceptors (token
+  refresh, logout, retries).
+  :::
+
+  ```ts
+  import axios, { AxiosAdapter, AxiosError, AxiosHeaders } from 'axios';
+  import { fetch } from 'react-native-nitro-fetch';
+
+  function buildURL(config: any): string {
+    let url = config.url ?? '';
+    if (config.baseURL && !/^https?:\/\//i.test(url)) {
+      url = config.baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
+    }
+    if (config.params) {
+      // Mirror axios's default param serialization rather than letting
+      // URLSearchParams stringify everything: skip null/undefined, expand
+      // arrays as repeated `key[]` entries, and serialize Dates as ISO.
+      const sp = new URLSearchParams();
+      for (const [key, value] of Object.entries(config.params)) {
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item === undefined || item === null) continue;
+            sp.append(`${key}[]`, item instanceof Date ? item.toISOString() : String(item));
+          }
+        } else if (value instanceof Date) {
+          sp.append(key, value.toISOString());
+        } else {
+          sp.append(key, String(value));
+        }
+      }
+      const qs = sp.toString();
+      if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+    }
+    return url;
   }
-  return url;
-}
 
-export const api = axios.create({ adapter: nitroAxiosAdapter });
-```
+  function serializeBody(data: unknown) {
+    if (data == null) return undefined;
+    if (
+      typeof data === 'string' ||
+      data instanceof ArrayBuffer ||
+      data instanceof FormData ||
+      data instanceof URLSearchParams
+    ) {
+      return data;
+    }
+    // axios usually runs transformRequest before the adapter, but guard against
+    // a raw object body if transforms are overridden.
+    return JSON.stringify(data);
+  }
+
+  const nitroAxiosAdapter: AxiosAdapter = async (config) => {
+    const url = buildURL(config);
+    const method = (config.method ?? 'get').toUpperCase();
+    const hasBody = method !== 'GET' && method !== 'HEAD';
+
+    const res = await fetch(url, {
+      method,
+      headers: AxiosHeaders.from(config.headers as any).toJSON() as Record<string, string>,
+      body: hasBody ? serializeBody(config.data) : undefined,
+      signal: config.signal,
+    });
+
+    const headers = new AxiosHeaders();
+    res.headers.forEach((v, k) => headers.set(k, v));
+
+    const data =
+      config.responseType === 'arraybuffer' ? await res.arrayBuffer()
+      : config.responseType === 'blob' ? await res.blob()
+      : config.responseType === 'text' ? await res.text()
+      : await res.json().catch(() => null);
+
+    const response = {
+      data,
+      status: res.status,
+      statusText: res.statusText,
+      headers,
+      config,
+      request: null,
+    };
+
+    // Mirror axios's `settle`: reject on error statuses so that downstream
+    // catch blocks and response interceptors (token refresh, logout, retries)
+    // run instead of treating a 4xx/5xx body as a successful payload.
+    const validateStatus = config.validateStatus;
+    if (!response.status || !validateStatus || validateStatus(response.status)) {
+      return response;
+    }
+    throw new AxiosError(
+      `Request failed with status code ${response.status}`,
+      [AxiosError.ERR_BAD_REQUEST, AxiosError.ERR_BAD_RESPONSE][Math.floor(response.status / 100) -
+  4],
+      config,
+      null,
+      response,
+    );
+  };
+
+  export const api = axios.create({ adapter: nitroAxiosAdapter });
+  ```

--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -1,171 +1,157 @@
-  ---
-  id: global-replace
-  title: Global Replace
-  sidebar_position: 1
-  ---
+---
+id: global-replace
+title: Global Replace
+sidebar_position: 1
+---
 
-  # Global Replace
+# Global Replace
 
-  By default you import `fetch` explicitly from `react-native-nitro-fetch` at each call site. If
-  you prefer a drop-in replacement so that **all** `fetch()` calls in your app (and third-party
-  libraries) go through Nitro, you can install it globally.
+By default you import `fetch` explicitly from `react-native-nitro-fetch` at each call site. If you prefer a drop-in replacement so that **all** `fetch()` calls in your app (and third-party libraries) go through Nitro, you can install it globally.
 
-  ## Setup
+## Setup
 
-  Add this at the **very top** of your entry file (before any other imports):
+Add this at the **very top** of your entry file (before any other imports):
 
-  ```ts
-  // index.js or App.tsx — must be the first import
-  import { fetch, Headers, Request, Response } from 'react-native-nitro-fetch';
+```ts
+// index.js or App.tsx — must be the first import
+import { fetch, Headers, Request, Response } from 'react-native-nitro-fetch';
 
-  globalThis.fetch = fetch;
-  globalThis.Headers = Headers;
-  globalThis.Request = Request;
-  globalThis.Response = Response;
-  ```
+globalThis.fetch = fetch;
+globalThis.Headers = Headers;
+globalThis.Request = Request;
+globalThis.Response = Response;
+```
 
-  That's it — every `fetch()` call in the process now uses the Nitro implementation.
+That's it — every `fetch()` call in the process now uses the Nitro implementation.
 
-  ## WebSocket
+## WebSocket
 
-  The same pattern works for the WebSocket package:
+The same pattern works for the WebSocket package:
 
-  ```ts
-  import { NitroWebSocket } from 'react-native-nitro-websockets';
+```ts
+import { NitroWebSocket } from 'react-native-nitro-websockets';
 
-  globalThis.WebSocket = NitroWebSocket;
-  ```
+globalThis.WebSocket = NitroWebSocket;
+```
 
-  :::tip
-  Many WebSocket libraries (Socket.IO, Centrifuge) accept a `WebSocket` constructor option —
-  passing `NitroWebSocket` there avoids touching the global entirely:
+:::tip
+Many WebSocket libraries (Socket.IO, Centrifuge) accept a `WebSocket` constructor option — passing `NitroWebSocket` there avoids touching the global entirely:
 
-  ```ts
-  import { io } from 'socket.io-client';
-  import { NitroWebSocket } from 'react-native-nitro-websockets';
+```ts
+import { io } from 'socket.io-client';
+import { NitroWebSocket } from 'react-native-nitro-websockets';
 
-  const socket = io('https://example.com', {
-    transports: ['websocket'],
-    WebSocket: NitroWebSocket,
-  });
-  ```
-  :::
+const socket = io('https://example.com', {
+  transports: ['websocket'],
+  WebSocket: NitroWebSocket,
+});
+```
+:::
 
-  ## Axios
+## Axios
 
-  If you use [axios](https://axios-http.com), you can route all requests through Nitro via a custom
-  adapter.
+If you use [axios](https://axios-http.com), you can route all requests through Nitro via a custom adapter.
 
-  :::warning
-  A custom adapter is responsible for two things that axios normally does for you. Skipping either
-  one produces bugs that only surface in edge cases — the happy path looks fine, so they tend to
-  reach production:
+:::warning
+A custom adapter is responsible for two things that axios normally does for you. Skipping either one produces bugs that only surface in edge cases — the happy path looks fine, so they tend to reach production:
 
-  1. **Param serialization.** Don't pass `config.params` straight into `URLSearchParams` — it
-  coerces every value with `String()`, so `undefined` becomes the literal `"undefined"`, arrays are
-  comma-joined instead of repeated as `key[]`, and `Date` objects become `"Tue May 29 2026…"`
-  instead of ISO. Axios's default serializer drops nullish values and expands arrays/Dates;
-  replicate that.
-  2. **Status handling.** Axios adapters must reject on non-2xx responses (this is what `settle()`
-  does internally). If you just return the response, every `4xx`/`5xx` resolves as a *success*,
-  which silently disables `try/catch`, status checks, and response error interceptors (token
-  refresh, logout, retries).
-  :::
+1. **Param serialization.** Don't pass `config.params` straight into `URLSearchParams` — it coerces every value with `String()`, so `undefined` becomes the literal `"undefined"`, arrays are comma-joined instead of repeated as `key[]`, and `Date` objects become `"Tue May 29 2026…"` instead of ISO. Axios's default serializer drops nullish values and expands arrays/Dates; replicate that.
+2. **Status handling.** Axios adapters must reject on non-2xx responses (this is what `settle()` does internally). If you just return the response, every `4xx`/`5xx` resolves as a *success*, which silently disables `try/catch`, status checks, and response error interceptors (token refresh, logout, retries).
+:::
 
-  ```ts
-  import axios, { AxiosAdapter, AxiosError, AxiosHeaders } from 'axios';
-  import { fetch } from 'react-native-nitro-fetch';
+```ts
+import axios, { AxiosAdapter, AxiosError, AxiosHeaders } from 'axios';
+import { fetch } from 'react-native-nitro-fetch';
 
-  function buildURL(config: any): string {
-    let url = config.url ?? '';
-    if (config.baseURL && !/^https?:\/\//i.test(url)) {
-      url = config.baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
-    }
-    if (config.params) {
-      // Mirror axios's default param serialization rather than letting
-      // URLSearchParams stringify everything: skip null/undefined, expand
-      // arrays as repeated `key[]` entries, and serialize Dates as ISO.
-      const sp = new URLSearchParams();
-      for (const [key, value] of Object.entries(config.params)) {
-        if (value === undefined || value === null) continue;
-        if (Array.isArray(value)) {
-          for (const item of value) {
-            if (item === undefined || item === null) continue;
-            sp.append(`${key}[]`, item instanceof Date ? item.toISOString() : String(item));
-          }
-        } else if (value instanceof Date) {
-          sp.append(key, value.toISOString());
-        } else {
-          sp.append(key, String(value));
+function buildURL(config: any): string {
+  let url = config.url ?? '';
+  if (config.baseURL && !/^https?:\/\//i.test(url)) {
+    url = config.baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
+  }
+  if (config.params) {
+    // Mirror axios's default param serialization rather than letting
+    // URLSearchParams stringify everything: skip null/undefined, expand
+    // arrays as repeated `key[]` entries, and serialize Dates as ISO.
+    const sp = new URLSearchParams();
+    for (const [key, value] of Object.entries(config.params)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item === undefined || item === null) continue;
+          sp.append(`${key}[]`, item instanceof Date ? item.toISOString() : String(item));
         }
+      } else if (value instanceof Date) {
+        sp.append(key, value.toISOString());
+      } else {
+        sp.append(key, String(value));
       }
-      const qs = sp.toString();
-      if (qs) url += (url.includes('?') ? '&' : '?') + qs;
     }
-    return url;
+    const qs = sp.toString();
+    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
   }
+  return url;
+}
 
-  function serializeBody(data: unknown) {
-    if (data == null) return undefined;
-    if (
-      typeof data === 'string' ||
-      data instanceof ArrayBuffer ||
-      data instanceof FormData ||
-      data instanceof URLSearchParams
-    ) {
-      return data;
-    }
-    // axios usually runs transformRequest before the adapter, but guard against
-    // a raw object body if transforms are overridden.
-    return JSON.stringify(data);
+function serializeBody(data: unknown) {
+  if (data == null) return undefined;
+  if (
+    typeof data === 'string' ||
+    data instanceof ArrayBuffer ||
+    data instanceof FormData ||
+    data instanceof URLSearchParams
+  ) {
+    return data;
   }
+  // axios usually runs transformRequest before the adapter, but guard against
+  // a raw object body if transforms are overridden.
+  return JSON.stringify(data);
+}
 
-  const nitroAxiosAdapter: AxiosAdapter = async (config) => {
-    const url = buildURL(config);
-    const method = (config.method ?? 'get').toUpperCase();
-    const hasBody = method !== 'GET' && method !== 'HEAD';
+const nitroAxiosAdapter: AxiosAdapter = async (config) => {
+  const url = buildURL(config);
+  const method = (config.method ?? 'get').toUpperCase();
+  const hasBody = method !== 'GET' && method !== 'HEAD';
 
-    const res = await fetch(url, {
-      method,
-      headers: AxiosHeaders.from(config.headers as any).toJSON() as Record<string, string>,
-      body: hasBody ? serializeBody(config.data) : undefined,
-      signal: config.signal,
-    });
+  const res = await fetch(url, {
+    method,
+    headers: AxiosHeaders.from(config.headers as any).toJSON() as Record<string, string>,
+    body: hasBody ? serializeBody(config.data) : undefined,
+    signal: config.signal,
+  });
 
-    const headers = new AxiosHeaders();
-    res.headers.forEach((v, k) => headers.set(k, v));
+  const headers = new AxiosHeaders();
+  res.headers.forEach((v, k) => headers.set(k, v));
 
-    const data =
-      config.responseType === 'arraybuffer' ? await res.arrayBuffer()
-      : config.responseType === 'blob' ? await res.blob()
-      : config.responseType === 'text' ? await res.text()
-      : await res.json().catch(() => null);
+  const data =
+    config.responseType === 'arraybuffer' ? await res.arrayBuffer()
+    : config.responseType === 'blob' ? await res.blob()
+    : config.responseType === 'text' ? await res.text()
+    : await res.json().catch(() => null);
 
-    const response = {
-      data,
-      status: res.status,
-      statusText: res.statusText,
-      headers,
-      config,
-      request: null,
-    };
-
-    // Mirror axios's `settle`: reject on error statuses so that downstream
-    // catch blocks and response interceptors (token refresh, logout, retries)
-    // run instead of treating a 4xx/5xx body as a successful payload.
-    const validateStatus = config.validateStatus;
-    if (!response.status || !validateStatus || validateStatus(response.status)) {
-      return response;
-    }
-    throw new AxiosError(
-      `Request failed with status code ${response.status}`,
-      [AxiosError.ERR_BAD_REQUEST, AxiosError.ERR_BAD_RESPONSE][Math.floor(response.status / 100) -
-  4],
-      config,
-      null,
-      response,
-    );
+  const response = {
+    data,
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+    config,
+    request: null,
   };
 
-  export const api = axios.create({ adapter: nitroAxiosAdapter });
-  ```
+  // Mirror axios's `settle`: reject on error statuses so that downstream
+  // catch blocks and response interceptors (token refresh, logout, retries)
+  // run instead of treating a 4xx/5xx body as a successful payload.
+  const validateStatus = config.validateStatus;
+  if (!response.status || !validateStatus || validateStatus(response.status)) {
+    return response;
+  }
+  throw new AxiosError(
+    `Request failed with status code ${response.status}`,
+    [AxiosError.ERR_BAD_REQUEST, AxiosError.ERR_BAD_RESPONSE][Math.floor(response.status / 100) - 4],
+    config,
+    null,
+    response,
+  );
+};
+
+export const api = axios.create({ adapter: nitroAxiosAdapter });
+```


### PR DESCRIPTION
The "Global Replace → Axios" doc example for routing axios through Nitro has two bugs that get
  copied verbatim into apps. Both pass a casual smoke test (a 2xx request with no optional params
  works), so they tend to surface only in production. This PR corrects the example and adds a
  warning explaining the two responsibilities a custom axios adapter must handle.

  ## The two issues

  ### 1. Param serialization

  ```ts
  const qs = new URLSearchParams(config.params).toString();
  ```

  `URLSearchParams` coerces every value with `String()`, which diverges from axios's default
  serializer:

  - `undefined`/`null` params become the literal string `"undefined"` / `"null"` instead of being omitted.
  - Arrays are comma-joined (`mccs=a,b`) instead of expanded as repeated `key[]` entries (`mccs[]=a&mccs[]=b`).
  - `Date` values become `"Tue May 29 2026 …"` instead of ISO 8601.

  In practice this means any request with optional query params silently sends garbage. In our case
  a `?searchString=undefined&limit=undefined` reached the backend, which rejected it (422) /
  filtered everything out — an endpoint returned empty for all users.

  ### 2. The adapter never rejects on error statuses

  ```ts
  return { data, status: res.status, ... };
  ```

  Axios's built-in adapters call `settle()`, which **rejects** when `validateStatus(status)` is
  false. Returning the response directly means every `4xx`/`5xx` resolves as a *success*. That
  silently disables:

  - `try/catch` error handling around requests,
  - status-code checks (`err.response?.status === 404`), (`api.interceptors.response.use(onFulfilled, onRejected)` never calls `onRejected`).

  The adapter *looks* correct because the happy path works, while the entire error path is dead.

  ## Fix

  - `buildURL` now mirrors axios's param serialization: skips nullish values, expands arrays as `key[]`, serializes `Date` as ISO.
  - The adapter honors `config.validateStatus` and throws an `AxiosError` (with `response` attached) on error statuses, matching `settle()`.
  - Minor defensive polish: a `serializeBody` helper and a `hasBody` guard so a raw object body isn't sent unserialized if `transformRequest` is overridden.

  The status-error construction (`[ERR_BAD_REQUEST, ERR_BAD_RESPONSE][Math.floor(status / 100) -
  4]`) is taken directly from axios's own `settle` implementation.

  ## Notes

  Docs-only change; no code in the package is affected.