### PR TITLE
docs refactor global replace axios

### DIFF
--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -46,112 +46,31 @@ const socket = io('https://example.com', {
   WebSocket: NitroWebSocket,
 });
 ```
+
 :::
 
 ## Axios
 
-If you use [axios](https://axios-http.com), you can route all requests through Nitro via a custom adapter.
+If you use [axios](https://axios-http.com), prefer axios's built-in fetch adapter and pass Nitro's `fetch` explicitly. This keeps the integration at the axios instance boundary instead of relying on global replacement.
 
 :::warning
-A custom adapter is responsible for two things that axios normally does for you. Skipping either one produces bugs that only surface in edge cases — the happy path looks fine, so they tend to reach production:
+Custom `env.fetch` support requires axios `v1.12.0` or newer.
 
-1. **Param serialization.** Don't pass `config.params` straight into `URLSearchParams` — it coerces every value with `String()`, so `undefined` becomes the literal `"undefined"`, arrays are comma-joined instead of repeated as `key[]`, and `Date` objects become `"Tue May 29 2026…"` instead of ISO. Axios's default serializer drops nullish values and expands arrays/Dates; replicate that.
-2. **Status handling.** Axios adapters must reject on non-2xx responses (this is what `settle()` does internally). If you just return the response, every `4xx`/`5xx` resolves as a *success*, which silently disables `try/catch`, status checks, and response error interceptors (token refresh, logout, retries).
+Setting `Request` and `Response` to `null` disables upload/download progress capture in axios's fetch adapter. Visit [axios adapter docs](https://axios.rest/pages/advanced/fetch-adapter.html) for more info
 :::
 
 ```ts
-import axios, { AxiosAdapter, AxiosError, AxiosHeaders } from 'axios';
-import { fetch } from 'react-native-nitro-fetch';
+import axios, { type AxiosRequestConfig } from 'axios';
+import { fetch as nitroFetch } from 'react-native-nitro-fetch';
 
-function buildURL(config: any): string {
-  let url = config.url ?? '';
-  if (config.baseURL && !/^https?:\/\//i.test(url)) {
-    url = config.baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
-  }
-  if (config.params) {
-    // Mirror axios's default param serialization rather than letting
-    // URLSearchParams stringify everything: skip null/undefined, expand
-    // arrays as repeated `key[]` entries, and serialize Dates as ISO.
-    const sp = new URLSearchParams();
-    for (const [key, value] of Object.entries(config.params)) {
-      if (value === undefined || value === null) continue;
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          if (item === undefined || item === null) continue;
-          sp.append(`${key}[]`, item instanceof Date ? item.toISOString() : String(item));
-        }
-      } else if (value instanceof Date) {
-        sp.append(key, value.toISOString());
-      } else {
-        sp.append(key, String(value));
-      }
-    }
-    const qs = sp.toString();
-    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
-  }
-  return url;
-}
+type AxiosEnv = NonNullable<AxiosRequestConfig['env']>;
 
-function serializeBody(data: unknown) {
-  if (data == null) return undefined;
-  if (
-    typeof data === 'string' ||
-    data instanceof ArrayBuffer ||
-    data instanceof FormData ||
-    data instanceof URLSearchParams
-  ) {
-    return data;
-  }
-  // axios usually runs transformRequest before the adapter, but guard against
-  // a raw object body if transforms are overridden.
-  return JSON.stringify(data);
-}
-
-const nitroAxiosAdapter: AxiosAdapter = async (config) => {
-  const url = buildURL(config);
-  const method = (config.method ?? 'get').toUpperCase();
-  const hasBody = method !== 'GET' && method !== 'HEAD';
-
-  const res = await fetch(url, {
-    method,
-    headers: AxiosHeaders.from(config.headers as any).toJSON() as Record<string, string>,
-    body: hasBody ? serializeBody(config.data) : undefined,
-    signal: config.signal,
-  });
-
-  const headers = new AxiosHeaders();
-  res.headers.forEach((v, k) => headers.set(k, v));
-
-  const data =
-    config.responseType === 'arraybuffer' ? await res.arrayBuffer()
-    : config.responseType === 'blob' ? await res.blob()
-    : config.responseType === 'text' ? await res.text()
-    : await res.json().catch(() => null);
-
-  const response = {
-    data,
-    status: res.status,
-    statusText: res.statusText,
-    headers,
-    config,
-    request: null,
-  };
-
-  // Mirror axios's `settle`: reject on error statuses so that downstream
-  // catch blocks and response interceptors (token refresh, logout, retries)
-  // run instead of treating a 4xx/5xx body as a successful payload.
-  const validateStatus = config.validateStatus;
-  if (!response.status || !validateStatus || validateStatus(response.status)) {
-    return response;
-  }
-  throw new AxiosError(
-    `Request failed with status code ${response.status}`,
-    [AxiosError.ERR_BAD_REQUEST, AxiosError.ERR_BAD_RESPONSE][Math.floor(response.status / 100) - 4],
-    config,
-    null,
-    response,
-  );
-};
-
-export const api = axios.create({ adapter: nitroAxiosAdapter });
+export const api = axios.create({
+  adapter: 'fetch',
+  env: {
+    fetch: nitroFetch,
+    Request: null as unknown as AxiosEnv['Request'],
+    Response: null as unknown as AxiosEnv['Response'],
+  },
+});
 ```

--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -56,7 +56,8 @@ If you use [axios](https://axios-http.com), prefer axios's built-in fetch adapte
 :::warning
 Custom `env.fetch` support requires axios `v1.12.0` or newer.
 
-Setting `Request` and `Response` to `null` disables upload/download progress capture in axios's fetch adapter. Visit [axios adapter docs](https://axios.rest/pages/advanced/fetch-adapter.html) for more info
+Setting `Request` and `Response` to `null` disables upload/download progress capture in axios's fetch adapter, Also if not set to null it will use global constructors as default, It is recommended to set it to null because Nitro Fetch Request/Response are not fully compatible with global one.
+Visit [axios adapter docs](https://axios.rest/pages/advanced/fetch-adapter.html) for more info
 :::
 
 ```ts

--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -60,7 +60,7 @@ Setting `Request` and `Response` to `null` disables upload/download progress cap
 :::
 
 ```ts
-import axios, { type AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 import { fetch as nitroFetch } from 'react-native-nitro-fetch';
 
 export const api = axios.create({

--- a/docs-website/docs/global-replace.md
+++ b/docs-website/docs/global-replace.md
@@ -63,14 +63,12 @@ Setting `Request` and `Response` to `null` disables upload/download progress cap
 import axios, { type AxiosRequestConfig } from 'axios';
 import { fetch as nitroFetch } from 'react-native-nitro-fetch';
 
-type AxiosEnv = NonNullable<AxiosRequestConfig['env']>;
-
 export const api = axios.create({
   adapter: 'fetch',
   env: {
     fetch: nitroFetch,
-    Request: null as unknown as AxiosEnv['Request'],
-    Response: null as unknown as AxiosEnv['Response'],
+    Request: null!,
+    Response: null!,
   },
 });
 ```


### PR DESCRIPTION
* Replace manual Axios adapter example with Axios fetch adapter

The "Global Replace -> Axios" docs previously showed a handwritten Axios adapter for routing
requests through Nitro Fetch. Axios now supports a built-in `fetch` adapter with a custom
`env.fetch`, so the docs can use Nitro's `fetch` directly without reimplementing Axios adapter
behavior by hand.

## Why

Manual adapter examples are easy to copy into apps, but they also make the docs responsible for
Axios behavior such as params serialization, request transforms, response parsing, cancellation,
timeouts, `validateStatus`, and interceptor-compatible errors.

Using Axios's built-in fetch adapter keeps those semantics inside Axios while still routing the
actual network call through Nitro.

## Change

The docs now recommend:

```ts
import axios, { type AxiosRequestConfig } from 'axios';
import { fetch as nitroFetch } from 'react-native-nitro-fetch';

type AxiosEnv = NonNullable<AxiosRequestConfig['env']>;

export const api = axios.create({
  adapter: 'fetch',
  env: {
    fetch: nitroFetch,
    Request: null as unknown as AxiosEnv['Request'],
    Response: null as unknown as AxiosEnv['Response'],
  },
});
