### PR TITLE
fix: gate token refresh header value logs behind debug builds

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -101,7 +101,9 @@ object AutoPrefetcher {
 
             val tokens: TokenRefreshResult = if (refreshed != null) {
               android.util.Log.d("NitroFetch", "[TokenRefresh] ✅ Success — got ${refreshed.headers.size} header(s)")
-              refreshed.headers.forEach { (k, v) -> android.util.Log.d("NitroFetch", "[TokenRefresh]   $k: $v") }
+              if (BuildConfig.DEBUG) {
+                refreshed.headers.forEach { (k, v) -> android.util.Log.d("NitroFetch", "[TokenRefresh]   $k: $v") }
+              }
               // Cache fresh tokens for useStoredHeaders fallback on next cold start
               NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
               refreshed
@@ -148,7 +150,9 @@ object AutoPrefetcher {
       merged["prefetchKey"] = prefetchKey
 
       android.util.Log.d("NitroFetch", "[TokenRefresh] Prefetching $url with ${merged.size} header(s)")
-      merged.forEach { (k, v) -> android.util.Log.d("NitroFetch", "[TokenRefresh]   $k: $v") }
+      if (BuildConfig.DEBUG) {
+        merged.forEach { (k, v) -> android.util.Log.d("NitroFetch", "[TokenRefresh]   $k: $v") }
+      }
       val req = buildNitroRequestFromEntry(url, merged, o, tokens)
 
       if (FetchCache.getPending(prefetchKey) != null) continue

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -150,7 +150,9 @@ public final class NitroAutoPrefetcher: NSObject {
         let refreshed = try? await callTokenRefresh(config: refreshObj)
         if let refreshed = refreshed {
           print("[NitroFetch][TokenRefresh] ✅ Success — got \(refreshed.headers.count) header(s)")
+          #if DEBUG
           for (k, v) in refreshed.headers { print("[NitroFetch][TokenRefresh]   \(k): \(v)") }
+          #endif
           // Cache fresh tokens for useStoredHeaders fallback on next cold start
           if let cacheStr = serializeCache(refreshed) {
             try? NitroFetchSecureAtRest.setEncrypted(cacheStr, forKey: tokenCacheKey, defaults: userDefaults)
@@ -188,7 +190,9 @@ public final class NitroAutoPrefetcher: NSObject {
         headers.append(NitroHeader(key: "prefetchKey", value: prefetchKey))
 
         print("[NitroFetch][TokenRefresh] Prefetching \(url) with \(merged.count) header(s)")
+        #if DEBUG
         for (k, v) in merged { print("[NitroFetch][TokenRefresh]   \(k): \(v)") }
+        #endif
 
         let req = buildNitroRequest(from: obj, mergedHeaders: headers, tokens: tokens)
         Task {


### PR DESCRIPTION
## Problem

The app-start token refresh path logs every header value unconditionally on both platforms:

- `AutoPrefetcher.kt` dumps `refreshed.headers` and the merged per-prefetch headers with `Log.d`
- `NitroAutoPrefetcher.swift` prints the same with `print`

These values include `Authorization: Bearer <refresh token>` from the stored token refresh config and the freshly minted access token from the refresh response. On Android, `Log.d` executes in release builds, so user tokens end up in logcat and inside any shared bug report. They are also re-logged on every cold start, so they are reliably present in the log buffer.

## Why this matters

To be clear, this is a minor issue, not a remote exploit: apps cannot read each other's logs on modern Android, so the exposure needs adb access or a shared bug report. But refresh tokens are long lived, they get re-logged on every cold start, and they ride along in any `bugreport.zip` a user sends to support. Secrets in device logs is also a standard security audit finding (OWASP MASVS), so apps adopting the token refresh feature currently inherit a flag they cannot fix without patching the library.

## Fix

Wrap the four header value dump lines in debug gates: `BuildConfig.DEBUG` on Android (matching the gating already used in `NitroFetchClient.kt`) and `#if DEBUG` on iOS. The surrounding count and status lines ("Success, got N header(s)", "Prefetching <url> with N header(s)") are untouched, so the `[TokenRefresh]` flow stays debuggable in release while the secrets only appear in debug builds.