### PR TITLE
Bump Cronet to 143.7445.0

### DIFF
--- a/docs/cronet-android.md
+++ b/docs/cronet-android.md
@@ -10,7 +10,9 @@ Android uses Google's **embedded Cronet** through the Java `CronetEngine` API, c
 api "org.chromium.net:cronet-embedded:${cronetVersion}"
 ```
 
-`cronetVersion` defaults to `141.7340.3` and can be overridden with a `NitroFetch_cronetVersion` gradle property. The embedded variant bundles the native Chromium net stack, so no Play Services dependency is required.
+`cronetVersion` defaults to `143.7445.0` and can be overridden with a `NitroFetch_cronetVersion` gradle property. The embedded variant bundles the native Chromium net stack, so no Play Services dependency is required.
+
+> **Note:** `143.7445.0` is the minimum version required to build with Android Gradle Plugin 9+. Earlier Cronet artifacts shared the `org.chromium.net` namespace across modules, which trips AGP 9's unique-namespace enforcement during manifest merge. Fixed upstream in [crbug 406926302](https://issues.chromium.org/issues/406926302).
 
 ## Engine
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -124,7 +124,9 @@ dependencies {
     }
 
     // Add Cronet Java implementation so CronetEngine.Builder() can find a provider.
-    // Keep version aligned with the libcronet you package.
-    def cronetVersion = project.rootProject.findProperty("NitroFetch_cronetVersion") ?: "119.6045.31"
+    // Keep version aligned with the libcronet you package (see
+    // packages/react-native-nitro-fetch/android/build.gradle). 143.7445.0+ is
+    // required for AGP 9 (unique namespaces) — https://issues.chromium.org/issues/406926302
+    def cronetVersion = project.rootProject.findProperty("NitroFetch_cronetVersion") ?: "143.7445.0"
     implementation("org.chromium.net:cronet-embedded:${cronetVersion}")
 }

--- a/packages/react-native-nitro-fetch/android/build.gradle
+++ b/packages/react-native-nitro-fetch/android/build.gradle
@@ -125,7 +125,11 @@ repositories {
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 // ---------- Cronet (Java API only) ----------
-def cronetVersion = (getExtOrDefault("cronetVersion") ?: "141.7340.3")
+// Pinned to 143.7445.0+: earlier Cronet artifacts shared the `org.chromium.net`
+// namespace across modules (cronet-embedded/common/api/shared/...), which fails
+// the AGP 9 unique-namespace check during manifest merge. Fixed upstream in
+// https://issues.chromium.org/issues/406926302
+def cronetVersion = (getExtOrDefault("cronetVersion") ?: "143.7445.0")
 
 
 dependencies {


### PR DESCRIPTION
Bumping Cronet version to make sure the library will keep on working on AGP 9.x

This will be needed for RN 0.87+

See: https://issues.chromium.org/issues/406926302