### PR TITLE
fix: preserve binary request bodies over base64

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetchClient.kt
@@ -295,7 +295,7 @@ class NitroFetchClient(private val engine: CronetEngine, private val executor: E
         val bodyStr = req.bodyString
         if ((bodyBytes != null) || !bodyStr.isNullOrEmpty()) {
           val body: ByteArray = when {
-            bodyBytes != null -> ByteArray(1)
+            bodyBytes != null -> android.util.Base64.decode(bodyBytes, android.util.Base64.DEFAULT)
             !bodyStr.isNullOrEmpty() -> bodyStr!!.toByteArray(Charsets.UTF_8)
             else -> ByteArray(0)
           }

--- a/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
@@ -334,6 +334,8 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
       let (body, contentType) = try await buildMultipartBody(parts)
       r.httpBody = body
       r.setValue(contentType, forHTTPHeaderField: "Content-Type")
+    } else if let bodyBytes = req.bodyBytes, let data = Data(base64Encoded: bodyBytes) {
+      r.httpBody = data
     } else if let s = req.bodyString {
       r.httpBody = s.data(using: .utf8)
     }

--- a/packages/react-native-nitro-fetch/src/__tests__/fetch.test.ts
+++ b/packages/react-native-nitro-fetch/src/__tests__/fetch.test.ts
@@ -1,0 +1,73 @@
+jest.mock('react-native-nitro-modules', () => ({
+  NitroModules: {
+    box: (value: unknown) => value,
+    createHybridObject: () => ({}),
+  },
+}));
+
+import { buildNitroRequestPure } from '../fetch';
+
+function buildRequest(body: BodyInit) {
+  return buildNitroRequestPure('https://example.com/upload', {
+    method: 'POST',
+    body,
+  });
+}
+
+describe('buildNitroRequestPure request bodies', () => {
+  it('encodes an ArrayBuffer as base64 for the current wire type', () => {
+    const body = new Uint8Array([0x00, 0x7f, 0x80, 0xff]).buffer;
+
+    const request = buildRequest(body);
+
+    expect(request.bodyString).toBeUndefined();
+    expect(request.bodyBytes).toBe('AH+A/w==');
+  });
+
+  it('encodes only the bytes in a typed-array subview', () => {
+    const backing = new Uint8Array([0xaa, 0x00, 0x01, 0x02, 0xbb]);
+
+    const request = buildRequest(backing.subarray(1, 4));
+
+    expect(request.bodyBytes).toBe('AAEC');
+  });
+
+  it('preserves an empty binary body', () => {
+    const request = buildRequest(new ArrayBuffer(0));
+
+    expect(request.bodyBytes).toBe('');
+  });
+
+  it('encodes non-ASCII bytes without text conversion', () => {
+    const request = buildRequest(
+      new Uint8Array([0x80, 0xff, 0xc3, 0xa9]).buffer
+    );
+
+    expect(request.bodyBytes).toBe('gP/DqQ==');
+  });
+
+  it('uses the worklet-safe fallback when btoa is unavailable', () => {
+    const originalBtoa = globalThis.btoa;
+    Object.defineProperty(globalThis, 'btoa', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const request = buildRequest(new Uint8Array([0x00, 0x01, 0x02]).buffer);
+      expect(request.bodyBytes).toBe('AAEC');
+    } finally {
+      Object.defineProperty(globalThis, 'btoa', {
+        configurable: true,
+        value: originalBtoa,
+      });
+    }
+  });
+
+  it('keeps string and URLSearchParams bodies on the string path', () => {
+    expect(buildRequest('hello').bodyString).toBe('hello');
+    expect(
+      buildRequest(new URLSearchParams({ message: 'café' })).bodyString
+    ).toBe('message=caf%C3%A9');
+  });
+});

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -17,7 +17,48 @@ import { NitroRequest as NitroRequestClass } from './Request';
 import type { RequestRedirect, RequestCache } from './Request';
 import { NetworkInspector } from './NetworkInspector';
 
-// No base64: pass strings/ArrayBuffers directly
+function bytesToBase64(buffer: ArrayBuffer): string {
+  'worklet';
+  const bytes = new Uint8Array(buffer);
+  const encode = (globalThis as { btoa?: (value: string) => string }).btoa;
+  if (typeof encode === 'function') {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]!);
+    }
+    return encode(binary);
+  }
+
+  // Keep the alphabet local so worklet serialization does not capture module scope.
+  /* eslint-disable no-bitwise */
+  const alphabet =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  let base64 = '';
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const value = (bytes[i]! << 16) | (bytes[i + 1]! << 8) | bytes[i + 2]!;
+    base64 +=
+      alphabet[(value >> 18) & 63] +
+      alphabet[(value >> 12) & 63] +
+      alphabet[(value >> 6) & 63] +
+      alphabet[value & 63];
+  }
+  const remaining = bytes.length - i;
+  if (remaining === 1) {
+    const value = bytes[i]! << 16;
+    base64 +=
+      alphabet[(value >> 18) & 63] + alphabet[(value >> 12) & 63] + '==';
+  } else if (remaining === 2) {
+    const value = (bytes[i]! << 16) | (bytes[i + 1]! << 8);
+    base64 +=
+      alphabet[(value >> 18) & 63] +
+      alphabet[(value >> 12) & 63] +
+      alphabet[(value >> 6) & 63] +
+      '=';
+  }
+  return base64;
+  /* eslint-enable no-bitwise */
+}
 
 function headersToPairs(headers?: HeadersInit): NitroHeader[] | undefined {
   'worklet';
@@ -233,7 +274,9 @@ function buildNitroRequest(
     method: (method?.toUpperCase() as any) ?? 'GET',
     headers: headers.length > 0 ? headers : undefined,
     bodyString: normalized?.bodyString,
-    bodyBytes: undefined as any,
+    bodyBytes: normalized?.bodyBytes
+      ? bytesToBase64(normalized.bodyBytes)
+      : undefined,
     bodyFormData: normalized?.bodyFormData,
     followRedirects,
     credentials: credentialsOption,
@@ -380,8 +423,9 @@ export function buildNitroRequestPure(
     method: (method?.toUpperCase() as any) ?? 'GET',
     headers,
     bodyString: normalized?.bodyString,
-    // Only include bodyBytes when provided to avoid signaling upload data unintentionally
-    bodyBytes: undefined as any,
+    bodyBytes: normalized?.bodyBytes
+      ? bytesToBase64(normalized.bodyBytes)
+      : undefined,
     followRedirects: true,
     credentials: init?.credentials,
     prefetchCacheTtlMs,


### PR DESCRIPTION
## Summary

- encode `ArrayBuffer` and typed-array request bodies as base64 at the existing string wire boundary
- decode that base64 into the actual upload bytes on iOS and Android
- cover full buffers, typed-array subviews, empty bodies, non-ASCII bytes, and the worklet-safe fallback
- keep string, `URLSearchParams`, and form-data handling unchanged

## Why

Binary request bodies are normalized in JavaScript today, but `bodyBytes` is then left unset. Even if it is provided, Android currently uploads a one-byte placeholder and iOS does not attach it to the request. This can drop or corrupt binary uploads.

This draft is an interim correctness fix: it intentionally retains the current `bodyBytes?: string` base64 transport and does not change the Nitro spec or generated ABI.

## Tests

- `bun --cwd packages/react-native-nitro-fetch test --runInBand src/__tests__/fetch.test.ts`
- `bun --cwd packages/react-native-nitro-fetch test --runInBand`
- `bun typecheck`
- `bun lint` (0 errors; 2 pre-existing `no-shadow` warnings)
- `git diff --check`

## Limitations / follow-up

The new coverage is a JavaScript contract test for the current base64 wire format. I did not run an iOS or Android app build in this checkout, so native decoding is not exercised by an integration test here.

#112 proposes the broader `ArrayBuffer` transport and generated binding changes. That remains the preferred follow-up; this draft is deliberately narrower so the request-body correctness fix can be reviewed independently without an ABI change.