### PR TITLE
fix: send ArrayBuffer request bodies safely

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -197,7 +197,6 @@ object AutoPrefetcher {
       put("headers", headersObj)
       if (method != null && method.isNotEmpty() && method != "GET") put("method", method)
       if (bodyString != null) put("bodyString", bodyString)
-      if (bodyBytes != null) put("bodyBytes", bodyBytes)
       if (!bodyFormData.isNullOrEmpty()) {
         val arr = JSONArray()
         bodyFormData.forEach { part ->
@@ -242,9 +241,6 @@ object AutoPrefetcher {
       .takeIf { it.has("bodyString") && !it.isNull("bodyString") }
       ?.optString("bodyString")
     val bodyString = injectBodyFields(rawBodyString, tokens.bodyFields)
-    val bodyBytes = entry
-      .takeIf { it.has("bodyBytes") && !it.isNull("bodyBytes") }
-      ?.optString("bodyBytes")
     val timeoutMs = entry
       .takeIf { it.has("timeoutMs") && !it.isNull("timeoutMs") }
       ?.optDouble("timeoutMs")
@@ -282,7 +278,7 @@ object AutoPrefetcher {
       method = method,
       headers = headerObjs,
       bodyString = bodyString,
-      bodyBytes = bodyBytes,
+      bodyBytes = null,
       bodyFormData = bodyFormData,
       timeoutMs = timeoutMs,
       followRedirects = followRedirects,

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetchClient.kt
@@ -295,7 +295,7 @@ class NitroFetchClient(private val engine: CronetEngine, private val executor: E
         val bodyStr = req.bodyString
         if ((bodyBytes != null) || !bodyStr.isNullOrEmpty()) {
           val body: ByteArray = when {
-            bodyBytes != null -> ByteArray(1)
+            bodyBytes != null -> bodyBytes.getBuffer(true).toByteArray()
             !bodyStr.isNullOrEmpty() -> bodyStr!!.toByteArray(Charsets.UTF_8)
             else -> ByteArray(0)
           }

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -208,7 +208,6 @@ public final class NitroAutoPrefetcher: NSObject {
     ]
     if let method = method, !method.isEmpty, method != "GET" { entry["method"] = method }
     if let bodyString = bodyString { entry["bodyString"] = bodyString }
-    if let bodyBytes = bodyBytes { entry["bodyBytes"] = bodyBytes }
     if let parts = bodyFormData, !parts.isEmpty {
       entry["bodyFormData"] = parts.map { part -> [String: String] in
         var clean: [String: String] = [:]
@@ -244,7 +243,6 @@ public final class NitroAutoPrefetcher: NSObject {
     let methodStr = entry["method"] as? String
     let method: NitroRequestMethod? = methodStr.flatMap { NitroRequestMethod(fromString: $0) }
     let bodyString = injectBodyFields(entry["bodyString"] as? String, fields: tokens.bodyFields)
-    let bodyBytes = entry["bodyBytes"] as? String
     let timeoutMs = (entry["timeoutMs"] as? NSNumber)?.doubleValue
     let followRedirects = (entry["followRedirects"] as? Bool) ?? true
     let credentials = (entry["credentials"] as? String).flatMap { NitroRequestCredentials(fromString: $0) }
@@ -266,7 +264,7 @@ public final class NitroAutoPrefetcher: NSObject {
       method: method,
       headers: headers,
       bodyString: bodyString,
-      bodyBytes: bodyBytes,
+      bodyBytes: nil,
       bodyFormData: formData,
       timeoutMs: timeoutMs,
       followRedirects: followRedirects,

--- a/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
@@ -34,10 +34,13 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
   func requestSync(req: NitroRequest) throws -> NitroResponse {
     let semaphore = DispatchSemaphore(value: 0)
     var result: Result<NitroResponse, Error>?
+    // JS-origin ArrayBuffers are borrowed. Materialize their bytes while this
+    // synchronous Hybrid method is still running on the JS thread.
+    let (preparedReq, bodyBytes) = NitroFetchClient.prepareRequest(req)
     
     Task {
       do {
-        let response = try await NitroFetchClient.requestStatic(req)
+        let response = try await NitroFetchClient.requestStatic(preparedReq, bodyBytes: bodyBytes)
         result = .success(response)
       } catch {
         result = .failure(error)
@@ -59,6 +62,8 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
   func request(req: NitroRequest) throws -> Promise<NitroResponse> {
     let promise = Promise<NitroResponse>.init()
     let requestId = req.requestId
+    // Never capture a borrowed JS ArrayBuffer in an asynchronous Task.
+    let (preparedReq, bodyBytes) = NitroFetchClient.prepareRequest(req)
 
     let task = Task { [weak self] in
       defer {
@@ -67,7 +72,7 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
         }
       }
       do {
-        let response = try await NitroFetchClient.requestStatic(req)
+        let response = try await NitroFetchClient.requestStatic(preparedReq, bodyBytes: bodyBytes)
         promise.resolve(withResult: response)
       } catch {
         promise.reject(withError: error)
@@ -82,9 +87,10 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
   
   func prefetch(req: NitroRequest) throws -> Promise<Void> {
     let promise = Promise<Void>.init()
+    let (preparedReq, bodyBytes) = NitroFetchClient.prepareRequest(req)
     Task {
       do {
-        try await NitroFetchClient.prefetchStatic(req)
+        try await NitroFetchClient.prefetchStatic(preparedReq, bodyBytes: bodyBytes)
         promise.resolve(withResult: ())
       } catch {
         promise.reject(withError: error)
@@ -118,6 +124,11 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
 
 
   public class func requestStatic(_ req: NitroRequest) async throws -> NitroResponse {
+    let (preparedReq, bodyBytes) = prepareRequest(req)
+    return try await requestStatic(preparedReq, bodyBytes: bodyBytes)
+  }
+
+  private class func requestStatic(_ req: NitroRequest, bodyBytes: Data?) async throws -> NitroResponse {
     // Local resources (file://, scheme-less paths) aren't HTTP; read off disk -> 200.
     if !isHttpURL(req.url) {
       return try makeLocalFileResponse(req)
@@ -163,7 +174,7 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
       }
     }
 
-    let (urlRequest, finalURL) = try await buildURLRequest(req)
+    let (urlRequest, finalURL) = try await buildURLRequest(req, bodyBytes: bodyBytes)
     let shouldFollowRedirects = req.followRedirects ?? true
     let delegate: URLSessionTaskDelegate? = shouldFollowRedirects ? nil : NoRedirectDelegate()
 
@@ -268,6 +279,11 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
   }
 
   public class func prefetchStatic(_ req: NitroRequest) async throws {
+    let (preparedReq, bodyBytes) = prepareRequest(req)
+    try await prefetchStatic(preparedReq, bodyBytes: bodyBytes)
+  }
+
+  private class func prefetchStatic(_ req: NitroRequest, bodyBytes: Data?) async throws {
     guard let key = findPrefetchKey(req) else {
       throw NSError(domain: "NitroFetch", code: -2, userInfo: [NSLocalizedDescriptionKey: "prefetch: missing 'prefetchKey' header"])
     }
@@ -284,7 +300,7 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
     FetchCache.addPending(key) { _ in /* ignored here */ }
     Task.detached {
       do {
-        let (urlRequest, finalURL) = try await buildURLRequest(req)
+        let (urlRequest, finalURL) = try await buildURLRequest(req, bodyBytes: bodyBytes)
         let (data, response) = try await session.data(for: urlRequest)
         guard let http = response as? HTTPURLResponse else {
           throw NSError(domain: "NitroFetch", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
@@ -321,7 +337,26 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
     return req.method?.stringValue
   }
 
-  private static func buildURLRequest(_ req: NitroRequest) async throws -> (URLRequest, URL?) {
+  private static func prepareRequest(_ req: NitroRequest) -> (NitroRequest, Data?) {
+    guard let arrayBuffer = req.bodyBytes else { return (req, nil) }
+    let bodyBytes = arrayBuffer.toData(copyIfNeeded: true)
+    let preparedReq = NitroRequest(
+      url: req.url,
+      method: req.method,
+      headers: req.headers,
+      bodyString: req.bodyString,
+      bodyBytes: nil,
+      bodyFormData: req.bodyFormData,
+      timeoutMs: req.timeoutMs,
+      followRedirects: req.followRedirects,
+      credentials: req.credentials,
+      prefetchCacheTtlMs: req.prefetchCacheTtlMs,
+      requestId: req.requestId
+    )
+    return (preparedReq, bodyBytes)
+  }
+
+  private static func buildURLRequest(_ req: NitroRequest, bodyBytes: Data?) async throws -> (URLRequest, URL?) {
     guard let url = URL(string: req.url) else {
       throw NSError(domain: "NitroFetch", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid URL: \(req.url)"])
     }
@@ -334,6 +369,8 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
       let (body, contentType) = try await buildMultipartBody(parts)
       r.httpBody = body
       r.setValue(contentType, forHTTPHeaderField: "Content-Type")
+    } else if let bodyBytes {
+      r.httpBody = bodyBytes
     } else if let s = req.bodyString {
       r.httpBody = s.data(using: .utf8)
     }

--- a/packages/react-native-nitro-fetch/nitrogen/generated/android/c++/JNitroRequest.hpp
+++ b/packages/react-native-nitro-fetch/nitrogen/generated/android/c++/JNitroRequest.hpp
@@ -18,6 +18,8 @@
 #include "NitroHeader.hpp"
 #include "NitroRequestCredentials.hpp"
 #include "NitroRequestMethod.hpp"
+#include <NitroModules/ArrayBuffer.hpp>
+#include <NitroModules/JArrayBuffer.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -49,8 +51,8 @@ namespace margelo::nitro::nitrofetch {
       jni::local_ref<jni::JArrayClass<JNitroHeader>> headers = this->getFieldValue(fieldHeaders);
       static const auto fieldBodyString = clazz->getField<jni::JString>("bodyString");
       jni::local_ref<jni::JString> bodyString = this->getFieldValue(fieldBodyString);
-      static const auto fieldBodyBytes = clazz->getField<jni::JString>("bodyBytes");
-      jni::local_ref<jni::JString> bodyBytes = this->getFieldValue(fieldBodyBytes);
+      static const auto fieldBodyBytes = clazz->getField<JArrayBuffer::javaobject>("bodyBytes");
+      jni::local_ref<JArrayBuffer::javaobject> bodyBytes = this->getFieldValue(fieldBodyBytes);
       static const auto fieldBodyFormData = clazz->getField<jni::JArrayClass<JNitroFormDataPart>>("bodyFormData");
       jni::local_ref<jni::JArrayClass<JNitroFormDataPart>> bodyFormData = this->getFieldValue(fieldBodyFormData);
       static const auto fieldTimeoutMs = clazz->getField<jni::JDouble>("timeoutMs");
@@ -77,7 +79,7 @@ namespace margelo::nitro::nitrofetch {
           return __vector;
         }()) : std::nullopt,
         bodyString != nullptr ? std::make_optional(bodyString->toStdString()) : std::nullopt,
-        bodyBytes != nullptr ? std::make_optional(bodyBytes->toStdString()) : std::nullopt,
+        bodyBytes != nullptr ? std::make_optional(bodyBytes->cthis()->getArrayBuffer()) : std::nullopt,
         bodyFormData != nullptr ? std::make_optional([&]() {
           size_t __size = bodyFormData->size();
           std::vector<NitroFormDataPart> __vector;
@@ -102,7 +104,7 @@ namespace margelo::nitro::nitrofetch {
      */
     [[maybe_unused]]
     static jni::local_ref<JNitroRequest::javaobject> fromCpp(const NitroRequest& value) {
-      using JSignature = JNitroRequest(jni::alias_ref<jni::JString>, jni::alias_ref<JNitroRequestMethod>, jni::alias_ref<jni::JArrayClass<JNitroHeader>>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JArrayClass<JNitroFormDataPart>>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<JNitroRequestCredentials>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JString>);
+      using JSignature = JNitroRequest(jni::alias_ref<jni::JString>, jni::alias_ref<JNitroRequestMethod>, jni::alias_ref<jni::JArrayClass<JNitroHeader>>, jni::alias_ref<jni::JString>, jni::alias_ref<JArrayBuffer::javaobject>, jni::alias_ref<jni::JArrayClass<JNitroFormDataPart>>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<JNitroRequestCredentials>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JString>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -120,7 +122,7 @@ namespace margelo::nitro::nitrofetch {
           return __array;
         }() : nullptr,
         value.bodyString.has_value() ? jni::make_jstring(value.bodyString.value()) : nullptr,
-        value.bodyBytes.has_value() ? jni::make_jstring(value.bodyBytes.value()) : nullptr,
+        value.bodyBytes.has_value() ? JArrayBuffer::wrap(value.bodyBytes.value()) : nullptr,
         value.bodyFormData.has_value() ? [&]() {
           size_t __size = value.bodyFormData.value().size();
           jni::local_ref<jni::JArrayClass<JNitroFormDataPart>> __array = jni::JArrayClass<JNitroFormDataPart>::newArray(__size);

--- a/packages/react-native-nitro-fetch/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrofetch/NitroRequest.kt
+++ b/packages/react-native-nitro-fetch/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrofetch/NitroRequest.kt
@@ -9,7 +9,7 @@ package com.margelo.nitro.nitrofetch
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
-
+import com.margelo.nitro.core.ArrayBuffer
 
 /**
  * Represents the JavaScript object/struct "NitroRequest".
@@ -31,7 +31,7 @@ data class NitroRequest(
   val bodyString: String?,
   @DoNotStrip
   @Keep
-  val bodyBytes: String?,
+  val bodyBytes: ArrayBuffer?,
   @DoNotStrip
   @Keep
   val bodyFormData: Array<NitroFormDataPart>?,
@@ -61,7 +61,7 @@ data class NitroRequest(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(url: String, method: NitroRequestMethod?, headers: Array<NitroHeader>?, bodyString: String?, bodyBytes: String?, bodyFormData: Array<NitroFormDataPart>?, timeoutMs: Double?, followRedirects: Boolean?, credentials: NitroRequestCredentials?, prefetchCacheTtlMs: Double?, requestId: String?): NitroRequest {
+    private fun fromCpp(url: String, method: NitroRequestMethod?, headers: Array<NitroHeader>?, bodyString: String?, bodyBytes: ArrayBuffer?, bodyFormData: Array<NitroFormDataPart>?, timeoutMs: Double?, followRedirects: Boolean?, credentials: NitroRequestCredentials?, prefetchCacheTtlMs: Double?, requestId: String?): NitroRequest {
       return NitroRequest(url, method, headers, bodyString, bodyBytes, bodyFormData, timeoutMs, followRedirects, credentials, prefetchCacheTtlMs, requestId)
     }
   }

--- a/packages/react-native-nitro-fetch/nitrogen/generated/ios/swift/NitroRequest.swift
+++ b/packages/react-native-nitro-fetch/nitrogen/generated/ios/swift/NitroRequest.swift
@@ -18,7 +18,7 @@ public extension NitroRequest {
   /**
    * Create a new instance of `NitroRequest`.
    */
-  init(url: String, method: NitroRequestMethod?, headers: [NitroHeader]?, bodyString: String?, bodyBytes: String?, bodyFormData: [NitroFormDataPart]?, timeoutMs: Double?, followRedirects: Bool?, credentials: NitroRequestCredentials?, prefetchCacheTtlMs: Double?, requestId: String?) {
+  init(url: String, method: NitroRequestMethod?, headers: [NitroHeader]?, bodyString: String?, bodyBytes: ArrayBuffer?, bodyFormData: [NitroFormDataPart]?, timeoutMs: Double?, followRedirects: Bool?, credentials: NitroRequestCredentials?, prefetchCacheTtlMs: Double?, requestId: String?) {
     self.init(std.string(url), { () -> bridge.std__optional_NitroRequestMethod_ in
       if let __unwrappedValue = method {
         return bridge.create_std__optional_NitroRequestMethod_(__unwrappedValue)
@@ -43,9 +43,9 @@ public extension NitroRequest {
       } else {
         return .init()
       }
-    }(), { () -> bridge.std__optional_std__string_ in
+    }(), { () -> bridge.std__optional_std__shared_ptr_ArrayBuffer__ in
       if let __unwrappedValue = bodyBytes {
-        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+        return bridge.create_std__optional_std__shared_ptr_ArrayBuffer__(__unwrappedValue.getArrayBuffer())
       } else {
         return .init()
       }
@@ -138,11 +138,11 @@ public extension NitroRequest {
   }
   
   @inline(__always)
-  var bodyBytes: String? {
-    return { () -> String? in
-      if bridge.has_value_std__optional_std__string_(self.__bodyBytes) {
-        let __unwrapped = bridge.get_std__optional_std__string_(self.__bodyBytes)
-        return String(__unwrapped)
+  var bodyBytes: ArrayBuffer? {
+    return { () -> ArrayBuffer? in
+      if bridge.has_value_std__optional_std__shared_ptr_ArrayBuffer__(self.__bodyBytes) {
+        let __unwrapped = bridge.get_std__optional_std__shared_ptr_ArrayBuffer__(self.__bodyBytes)
+        return ArrayBuffer(__unwrapped)
       } else {
         return nil
       }

--- a/packages/react-native-nitro-fetch/nitrogen/generated/shared/c++/NitroRequest.hpp
+++ b/packages/react-native-nitro-fetch/nitrogen/generated/shared/c++/NitroRequest.hpp
@@ -42,6 +42,7 @@ namespace margelo::nitro::nitrofetch { enum class NitroRequestCredentials; }
 #include <optional>
 #include "NitroHeader.hpp"
 #include <vector>
+#include <NitroModules/ArrayBuffer.hpp>
 #include "NitroFormDataPart.hpp"
 #include "NitroRequestCredentials.hpp"
 
@@ -56,7 +57,7 @@ namespace margelo::nitro::nitrofetch {
     std::optional<NitroRequestMethod> method     SWIFT_PRIVATE;
     std::optional<std::vector<NitroHeader>> headers     SWIFT_PRIVATE;
     std::optional<std::string> bodyString     SWIFT_PRIVATE;
-    std::optional<std::string> bodyBytes     SWIFT_PRIVATE;
+    std::optional<std::shared_ptr<ArrayBuffer>> bodyBytes     SWIFT_PRIVATE;
     std::optional<std::vector<NitroFormDataPart>> bodyFormData     SWIFT_PRIVATE;
     std::optional<double> timeoutMs     SWIFT_PRIVATE;
     std::optional<bool> followRedirects     SWIFT_PRIVATE;
@@ -66,7 +67,7 @@ namespace margelo::nitro::nitrofetch {
 
   public:
     NitroRequest() = default;
-    explicit NitroRequest(std::string url, std::optional<NitroRequestMethod> method, std::optional<std::vector<NitroHeader>> headers, std::optional<std::string> bodyString, std::optional<std::string> bodyBytes, std::optional<std::vector<NitroFormDataPart>> bodyFormData, std::optional<double> timeoutMs, std::optional<bool> followRedirects, std::optional<NitroRequestCredentials> credentials, std::optional<double> prefetchCacheTtlMs, std::optional<std::string> requestId): url(url), method(method), headers(headers), bodyString(bodyString), bodyBytes(bodyBytes), bodyFormData(bodyFormData), timeoutMs(timeoutMs), followRedirects(followRedirects), credentials(credentials), prefetchCacheTtlMs(prefetchCacheTtlMs), requestId(requestId) {}
+    explicit NitroRequest(std::string url, std::optional<NitroRequestMethod> method, std::optional<std::vector<NitroHeader>> headers, std::optional<std::string> bodyString, std::optional<std::shared_ptr<ArrayBuffer>> bodyBytes, std::optional<std::vector<NitroFormDataPart>> bodyFormData, std::optional<double> timeoutMs, std::optional<bool> followRedirects, std::optional<NitroRequestCredentials> credentials, std::optional<double> prefetchCacheTtlMs, std::optional<std::string> requestId): url(url), method(method), headers(headers), bodyString(bodyString), bodyBytes(bodyBytes), bodyFormData(bodyFormData), timeoutMs(timeoutMs), followRedirects(followRedirects), credentials(credentials), prefetchCacheTtlMs(prefetchCacheTtlMs), requestId(requestId) {}
 
   public:
     friend bool operator==(const NitroRequest& lhs, const NitroRequest& rhs) = default;
@@ -86,7 +87,7 @@ namespace margelo::nitro {
         JSIConverter<std::optional<margelo::nitro::nitrofetch::NitroRequestMethod>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "method"))),
         JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroHeader>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "headers"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyString"))),
-        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes"))),
+        JSIConverter<std::optional<std::shared_ptr<ArrayBuffer>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes"))),
         JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroFormDataPart>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyFormData"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "timeoutMs"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "followRedirects"))),
@@ -101,7 +102,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "method"), JSIConverter<std::optional<margelo::nitro::nitrofetch::NitroRequestMethod>>::toJSI(runtime, arg.method));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "headers"), JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroHeader>>>::toJSI(runtime, arg.headers));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bodyString"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bodyString));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bodyBytes));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes"), JSIConverter<std::optional<std::shared_ptr<ArrayBuffer>>>::toJSI(runtime, arg.bodyBytes));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bodyFormData"), JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroFormDataPart>>>::toJSI(runtime, arg.bodyFormData));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "timeoutMs"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.timeoutMs));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "followRedirects"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.followRedirects));
@@ -122,7 +123,7 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<margelo::nitro::nitrofetch::NitroRequestMethod>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "method")))) return false;
       if (!JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroHeader>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "headers")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyString")))) return false;
-      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes")))) return false;
+      if (!JSIConverter<std::optional<std::shared_ptr<ArrayBuffer>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyBytes")))) return false;
       if (!JSIConverter<std::optional<std::vector<margelo::nitro::nitrofetch::NitroFormDataPart>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bodyFormData")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "timeoutMs")))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "followRedirects")))) return false;

--- a/packages/react-native-nitro-fetch/src/NitroFetch.nitro.ts
+++ b/packages/react-native-nitro-fetch/src/NitroFetch.nitro.ts
@@ -32,7 +32,7 @@ export interface NitroRequest {
   headers?: NitroHeader[];
   // Body as either UTF-8 string or raw bytes.
   bodyString?: string;
-  bodyBytes?: string; //will be ArrayBuffer in future
+  bodyBytes?: ArrayBuffer;
   // Multipart form data parts (for file uploads)
   bodyFormData?: NitroFormDataPart[];
   // Controls

--- a/packages/react-native-nitro-fetch/src/__tests__/fetch.test.ts
+++ b/packages/react-native-nitro-fetch/src/__tests__/fetch.test.ts
@@ -1,0 +1,73 @@
+jest.mock('react-native-nitro-modules', () => ({
+  NitroModules: {
+    box: (value: unknown) => value,
+    createHybridObject: () => ({}),
+  },
+}));
+
+import { buildNitroRequestPure } from '../fetch';
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
+}
+
+describe('buildNitroRequestPure', () => {
+  it('passes ArrayBuffer request bodies through as bodyBytes', () => {
+    const bytes = new Uint8Array([0x00, 0x7f, 0x80, 0xff]);
+    const req = buildNitroRequestPure('https://example.com/upload', {
+      method: 'POST',
+      body: toArrayBuffer(bytes),
+    });
+
+    expect(req.bodyString).toBeUndefined();
+    expect(req.bodyBytes).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(req.bodyBytes as ArrayBuffer)).toEqual(bytes);
+  });
+
+  it('copies typed array request bodies into exact bodyBytes', () => {
+    const backing = new Uint8Array([0xaa, 0x00, 0x01, 0x02, 0xbb]);
+    const view = backing.subarray(1, 4);
+    const req = buildNitroRequestPure('https://example.com/upload', {
+      method: 'POST',
+      body: view,
+    });
+
+    expect(req.bodyString).toBeUndefined();
+    expect(new Uint8Array(req.bodyBytes as ArrayBuffer)).toEqual(
+      new Uint8Array([0x00, 0x01, 0x02])
+    );
+  });
+
+  it('preserves an empty ArrayBuffer request body', () => {
+    const req = buildNitroRequestPure('https://example.com/upload', {
+      method: 'POST',
+      body: new ArrayBuffer(0),
+    });
+
+    expect(req.bodyString).toBeUndefined();
+    expect((req.bodyBytes as ArrayBuffer).byteLength).toBe(0);
+  });
+
+  it('preserves non-ASCII UTF-8 bytes without base64 encoding', () => {
+    const bytes = new TextEncoder().encode('héllø 🌍');
+    const req = buildNitroRequestPure('https://example.com/upload', {
+      method: 'POST',
+      body: bytes,
+    });
+
+    expect(new Uint8Array(req.bodyBytes as ArrayBuffer)).toEqual(bytes);
+  });
+
+  it('keeps string bodies on the string path', () => {
+    const req = buildNitroRequestPure('https://example.com/upload', {
+      method: 'POST',
+      body: 'héllø 🌍',
+    });
+
+    expect(req.bodyString).toBe('héllø 🌍');
+    expect(req.bodyBytes).toBeUndefined();
+  });
+});

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -233,7 +233,7 @@ function buildNitroRequest(
     method: (method?.toUpperCase() as any) ?? 'GET',
     headers: headers.length > 0 ? headers : undefined,
     bodyString: normalized?.bodyString,
-    bodyBytes: undefined as any,
+    bodyBytes: normalized?.bodyBytes,
     bodyFormData: normalized?.bodyFormData,
     followRedirects,
     credentials: credentialsOption,
@@ -380,8 +380,7 @@ export function buildNitroRequestPure(
     method: (method?.toUpperCase() as any) ?? 'GET',
     headers,
     bodyString: normalized?.bodyString,
-    // Only include bodyBytes when provided to avoid signaling upload data unintentionally
-    bodyBytes: undefined as any,
+    bodyBytes: normalized?.bodyBytes,
     followRedirects: true,
     credentials: init?.credentials,
     prefetchCacheTtlMs,
@@ -969,8 +968,6 @@ export async function prefetchOnAppStart(
   };
   if (req.method && req.method !== 'GET') entry.method = req.method;
   if (req.bodyString !== undefined) entry.bodyString = req.bodyString;
-  if (typeof req.bodyBytes === 'string' && req.bodyBytes.length > 0)
-    entry.bodyBytes = req.bodyBytes;
   if (req.bodyFormData && req.bodyFormData.length > 0)
     entry.bodyFormData = req.bodyFormData;
   if (typeof req.timeoutMs === 'number') entry.timeoutMs = req.timeoutMs;


### PR DESCRIPTION
## Summary

- Send binary request bodies through Nitro as `ArrayBuffer`, without a base64 round trip, in both normal JS and worklet request construction.
- Regenerate the Nitrogen C++/Swift/Kotlin bindings and upload native `Data`/`ByteArray` payloads on iOS and Android.
- Cover `ArrayBuffer`, `Uint8Array` subviews, empty bodies, non-ASCII bytes, and unchanged string behavior.

## Why

`bodyBytes` is currently typed as a string placeholder, and the request path does not upload the actual binary payload. A base64 bridge can restore correctness temporarily, but it adds encoding/decoding work and memory overhead. This PR carries the bytes as an `ArrayBuffer` instead.

## Credit and relationship to existing work

Builds on and credits #112. The original commit remains authored by its contributor, and this draft intentionally preserves that approach rather than presenting it as unrelated work.

This is a separate PR because it rebases the change onto current `main` and adds the iOS lifetime fix described below. It is not intended as silent competition with #112; maintainers are welcome to choose the preferred PR or merge the safety work into the original approach.

#138 is a temporary correctness/base64 fallback. The two PRs are alternatives/stages, not changes that should both remain in the final implementation long-term.

## iOS ArrayBuffer lifetime

Local native validation exposed a crash with the runtime diagnostic:

> `data() can only be accessed synchronously on the JS Thread... copy it first`

The `JSArrayBuffer` passed into a Hybrid method is borrowed and must not survive the synchronous JS call boundary. Calling `ArrayBufferHolder.toData(copyIfNeeded:)` later from a Swift `Task` or detached work accesses it from the wrong thread.

`request`, `requestSync`, and `prefetch` now synchronously materialize the body as native `Data` before creating any `Task`. The request passed across the async boundary is rebuilt without the borrowed `ArrayBuffer`, and only native-safe values plus the copied `Data` are captured. Android similarly copies into a `ByteArray` before the Cronet request starts.

## Compatibility and limitations

- This uses native `Data`/`ByteArray` copies; it is intentionally safe, not zero-copy.
- The generated native ABI changes from string to `ArrayBuffer`, so apps must perform a native rebuild after upgrading. This should be called out in release notes; callers using the old placeholder string form must migrate.
- String bodies and FormData keep their existing paths.
- Runtime `prefetch()` supports binary bodies with the same synchronous lifetime copy. Persisted app-start prefetch configuration does not serialize a borrowed `ArrayBuffer`; legacy string `bodyBytes` entries are no longer forwarded as binary data.

## Validation

- `bun install`
- `bun run nitrogen`
- `bun --cwd packages/react-native-nitro-fetch test --runInBand` — 15 passed, 2 existing todos
- `bun run typecheck`
- pre-commit `lint` and `types` hooks
- ESLint and Prettier checks for the new request-body test

A clean native app rebuild and benchmark rerun are still pending. The iOS lifetime fix is based on the local native crash report above; no native benchmark numbers are claimed here.