### PR TITLE
feat: add global logger, off by default in release

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -95,29 +95,29 @@ object AutoPrefetcher {
             val refreshConfig = JSONObject(refreshRaw)
             val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
             val refreshURL = refreshConfig.optString("url", "(unknown)")
-            android.util.Log.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
+            NitroLogger.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
 
             val refreshed = callTokenRefreshSync(refreshConfig)
 
             val tokens: TokenRefreshResult = if (refreshed != null) {
-              android.util.Log.d(
+              NitroLogger.d(
                 "NitroFetch",
                 "[TokenRefresh] ✅ Success — got ${refreshed.headers.size} header(s), " +
                   "${refreshed.bodyFields.size} body field(s), ${refreshed.formFields.size} form field(s)"
               )
-              if (BuildConfig.DEBUG) logTokens(refreshed)
+              logTokens(refreshed)
               // Cache fresh tokens for useStoredHeaders fallback on next cold start
               NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
               refreshed
             } else {
-              android.util.Log.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
+              NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
               if (onFailure == "skip") {
-                android.util.Log.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
+                NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
                 return@Thread
               }
               // Use last cached tokens (or empty if none cached yet)
               val cached = deserializeCache(NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_CACHE))
-              android.util.Log.d(
+              NitroLogger.d(
                 "NitroFetch",
                 "[TokenRefresh] Using cached tokens (${cached.headers.size} header(s), " +
                   "${cached.bodyFields.size} body field(s), ${cached.formFields.size} form field(s))"
@@ -125,7 +125,7 @@ object AutoPrefetcher {
               cached
             }
 
-            android.util.Log.d("NitroFetch", "[TokenRefresh] Injecting tokens into ${arr.length()} prefetch URL(s)")
+            NitroLogger.d("NitroFetch", "[TokenRefresh] Injecting tokens into ${arr.length()} prefetch URL(s)")
             startPrefetches(arr, tokens)
           } catch (_: Throwable) {
             // Best-effort — never crash the app
@@ -146,8 +146,8 @@ object AutoPrefetcher {
       val url = o.optString("url", null) ?: continue
       val prefetchKey = o.optString("prefetchKey", null) ?: continue
 
-      android.util.Log.d("NitroFetch", "[TokenRefresh] Prefetching $url")
-      if (BuildConfig.DEBUG) logTokens(tokens)
+      NitroLogger.d("NitroFetch", "[TokenRefresh] Prefetching $url")
+      logTokens(tokens)
 
       val req = buildNitroRequestFromEntry(o, tokens)
 
@@ -297,21 +297,21 @@ object AutoPrefetcher {
 
   private fun logTokens(tokens: TokenRefreshResult) {
     if (tokens.headers.isNotEmpty()) {
-      android.util.Log.d("NitroFetch", "[TokenRefresh]   headers:")
+      NitroLogger.d("NitroFetch", "[TokenRefresh]   headers:")
       tokens.headers.forEach { (k, v) ->
-        android.util.Log.d("NitroFetch", "[TokenRefresh]     $k: $v")
+        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
       }
     }
     if (tokens.bodyFields.isNotEmpty()) {
-      android.util.Log.d("NitroFetch", "[TokenRefresh]   body fields:")
+      NitroLogger.d("NitroFetch", "[TokenRefresh]   body fields:")
       tokens.bodyFields.forEach { (k, v) ->
-        android.util.Log.d("NitroFetch", "[TokenRefresh]     $k: $v")
+        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
       }
     }
     if (tokens.formFields.isNotEmpty()) {
-      android.util.Log.d("NitroFetch", "[TokenRefresh]   form fields:")
+      NitroLogger.d("NitroFetch", "[TokenRefresh]   form fields:")
       tokens.formFields.forEach { (k, v) ->
-        android.util.Log.d("NitroFetch", "[TokenRefresh]     $k: $v")
+        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
       }
     }
   }
@@ -356,7 +356,7 @@ object AutoPrefetcher {
 
       val status = conn.responseCode
       if (status !in 200..299) {
-        android.util.Log.d("NitroFetch", "[TokenRefresh] Refresh endpoint returned HTTP $status")
+        NitroLogger.d("NitroFetch", "[TokenRefresh] Refresh endpoint returned HTTP $status")
         return null
       }
 

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NativeStorage.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NativeStorage.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
-import android.util.Log
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.NitroModules
 import java.security.KeyStore
@@ -121,14 +120,14 @@ class NativeStorage : HybridNativeStorageSpec() {
     return try {
       val value = sharedPreferences.getString(key, null)
       if (value != null) {
-        Log.d(TAG, "Retrieved value for key: $key")
+        NitroLogger.d(TAG, "Retrieved value for key: $key")
         value
       } else {
-        Log.d(TAG, "Key not found: $key, returning empty string")
+        NitroLogger.d(TAG, "Key not found: $key, returning empty string")
         ""
       }
     } catch (t: Throwable) {
-      Log.e(TAG, "Error getting string for key: $key", t)
+      NitroLogger.e(TAG, "Error getting string for key: $key", t)
       throw RuntimeException("Failed to get string for key: $key", t)
     }
   }
@@ -139,13 +138,13 @@ class NativeStorage : HybridNativeStorageSpec() {
       editor.putString(key, value)
       val success = editor.commit()
       if (success) {
-        Log.d(TAG, "Successfully stored value for key: $key")
+        NitroLogger.d(TAG, "Successfully stored value for key: $key")
       } else {
-        Log.e(TAG, "Failed to commit value for key: $key")
+        NitroLogger.e(TAG, "Failed to commit value for key: $key")
         throw RuntimeException("Failed to store value for key: $key")
       }
     } catch (t: Throwable) {
-      Log.e(TAG, "Error setting string for key: $key", t)
+      NitroLogger.e(TAG, "Error setting string for key: $key", t)
       throw RuntimeException("Failed to set string for key: $key", t)
     }
   }
@@ -156,13 +155,13 @@ class NativeStorage : HybridNativeStorageSpec() {
       editor.remove(key)
       val success = editor.commit()
       if (success) {
-        Log.d(TAG, "Successfully deleted key: $key")
+        NitroLogger.d(TAG, "Successfully deleted key: $key")
       } else {
-        Log.e(TAG, "Failed to commit deletion for key: $key")
+        NitroLogger.e(TAG, "Failed to commit deletion for key: $key")
         throw RuntimeException("Failed to delete key: $key")
       }
     } catch (t: Throwable) {
-      Log.e(TAG, "Error deleting key: $key", t)
+      NitroLogger.e(TAG, "Error deleting key: $key", t)
       throw RuntimeException("Failed to delete key: $key", t)
     }
   }
@@ -171,7 +170,7 @@ class NativeStorage : HybridNativeStorageSpec() {
     return try {
       NitroFetchSecureAtRest.getDecryptedForPrefs(sharedPreferences, key) ?: ""
     } catch (t: Throwable) {
-      Log.e(TAG, "Error getSecureString for key: $key", t)
+      NitroLogger.e(TAG, "Error getSecureString for key: $key", t)
       throw RuntimeException("Failed to get secure string for key: $key", t)
     }
   }
@@ -181,7 +180,7 @@ class NativeStorage : HybridNativeStorageSpec() {
       val ok = NitroFetchSecureAtRest.putEncrypted(sharedPreferences, key, value)
       if (!ok) throw RuntimeException("commit failed")
     } catch (t: Throwable) {
-      Log.e(TAG, "Error setSecureString for key: $key", t)
+      NitroLogger.e(TAG, "Error setSecureString for key: $key", t)
       throw RuntimeException("Failed to set secure string for key: $key", t)
     }
   }
@@ -191,7 +190,7 @@ class NativeStorage : HybridNativeStorageSpec() {
       val ok = NitroFetchSecureAtRest.removeFromPrefs(sharedPreferences, key)
       if (!ok) throw RuntimeException("commit failed")
     } catch (t: Throwable) {
-      Log.e(TAG, "Error removeSecureString for key: $key", t)
+      NitroLogger.e(TAG, "Error removeSecureString for key: $key", t)
       throw RuntimeException("Failed to remove secure string for key: $key", t)
     }
   }

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroCookieSync.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroCookieSync.kt
@@ -1,6 +1,5 @@
 package com.margelo.nitro.nitrofetch
 
-import android.util.Log
 import android.webkit.CookieManager
 import org.json.JSONObject
 import org.chromium.net.UrlResponseInfo
@@ -60,7 +59,7 @@ object NitroCookieSync {
         addHeader("Cookie", cookieHeader)
       }
     } catch (exception: Exception) {
-      Log.w(LOG_TAG, "Failed to attach cookie header", exception)
+      NitroLogger.w(LOG_TAG, "Failed to attach cookie header", exception)
     }
   }
 
@@ -90,7 +89,7 @@ object NitroCookieSync {
       }
       true
     } catch (exception: Exception) {
-      Log.w(LOG_TAG, "Failed to store response cookies", exception)
+      NitroLogger.w(LOG_TAG, "Failed to store response cookies", exception)
       false
     }
   }
@@ -121,7 +120,7 @@ object NitroCookieSync {
       }
       anySet
     } catch (exception: Exception) {
-      Log.w(LOG_TAG, "Failed to store response cookies (HttpURLConnection)", exception)
+      NitroLogger.w(LOG_TAG, "Failed to store response cookies (HttpURLConnection)", exception)
       false
     }
   }
@@ -132,7 +131,7 @@ object NitroCookieSync {
     try {
       CookieManager.getInstance().flush()
     } catch (exception: Exception) {
-      Log.w(LOG_TAG, "Failed to flush CookieManager", exception)
+      NitroLogger.w(LOG_TAG, "Failed to flush CookieManager", exception)
     }
   }
 }

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetch.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroFetch.kt
@@ -1,7 +1,6 @@
 package com.margelo.nitro.nitrofetch
 
 import android.app.Application
-import android.util.Log
 import com.facebook.proguard.annotations.DoNotStrip
 import org.chromium.net.CronetEngine
 import org.chromium.net.CronetProvider
@@ -40,7 +39,7 @@ class NitroFetch : HybridNitroFetchSpec() {
 
         // Log available providers and prefer the Native one (avoids Play-Services DNS quirks)
         val providers = CronetProvider.getAllProviders(app)
-        providers.forEach { Log.i("NitroFetch", "Cronet provider: ${it.name} v=${it.version}") }
+        providers.forEach { NitroLogger.i("NitroFetch", "Cronet provider: ${it.name} v=${it.version}") }
         val nativeProvider = providers.firstOrNull { it.name.contains("Native", ignoreCase = true) }
 
         val cacheDir = File(app.cacheDir, "nitrofetch_cronet_cache").apply { mkdirs() }
@@ -61,7 +60,7 @@ class NitroFetch : HybridNitroFetchSpec() {
         // builder.setExperimentalOptions("""{"HostResolverRules":{"host_resolver_rules":"MAP httpbin.org 54.167.17.38"}}""")
 
         val engine = builder.build()
-        Log.i("NitroFetch", "CronetEngine initialized. Provider=${nativeProvider?.name ?: "Default"} Cache=${cacheDir.absolutePath}")
+        NitroLogger.i("NitroFetch", "CronetEngine initialized. Provider=${nativeProvider?.name ?: "Default"} Cache=${cacheDir.absolutePath}")
         engineRef = engine
         return engine
       }

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroLogger.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/NitroLogger.kt
@@ -1,0 +1,13 @@
+package com.margelo.nitro.nitrofetch
+
+import android.util.Log
+
+/** Flip [enabled] to log in release builds too. */
+object NitroLogger {
+  @JvmField var enabled: Boolean = BuildConfig.DEBUG
+
+  fun d(tag: String, msg: String) { if (enabled) Log.d(tag, msg) }
+  fun i(tag: String, msg: String) { if (enabled) Log.i(tag, msg) }
+  fun w(tag: String, msg: String, t: Throwable? = null) { if (enabled) Log.w(tag, msg, t) }
+  fun e(tag: String, msg: String, t: Throwable? = null) { if (enabled) Log.e(tag, msg, t) }
+}

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -139,27 +139,25 @@ public final class NitroAutoPrefetcher: NSObject {
          let refreshObj = try? JSONSerialization.jsonObject(with: refreshData) as? [String: Any] {
         let onFailure = refreshObj["onFailure"] as? String ?? "useStoredHeaders"
         let refreshURL = refreshObj["url"] as? String ?? "(unknown)"
-        print("[NitroFetch][TokenRefresh] Calling refresh endpoint: \(refreshURL)")
+        NitroLogger.log("[NitroFetch][TokenRefresh] Calling refresh endpoint: \(refreshURL)")
         let refreshed = try? await callTokenRefresh(config: refreshObj)
         if let refreshed = refreshed {
-          print("[NitroFetch][TokenRefresh] ✅ Success — got \(refreshed.headers.count) header(s), \(refreshed.bodyFields.count) body field(s), \(refreshed.formFields.count) form field(s)")
-          #if DEBUG
+          NitroLogger.log("[NitroFetch][TokenRefresh] ✅ Success — got \(refreshed.headers.count) header(s), \(refreshed.bodyFields.count) body field(s), \(refreshed.formFields.count) form field(s)")
           logTokens(refreshed)
-          #endif
           // Cache fresh tokens for useStoredHeaders fallback on next cold start
           if let cacheStr = serializeCache(refreshed) {
             try? NitroFetchSecureAtRest.setEncrypted(cacheStr, forKey: tokenCacheKey, defaults: userDefaults)
           }
           tokens = refreshed
         } else {
-          print("[NitroFetch][TokenRefresh] ❌ Refresh failed — onFailure: \(onFailure)")
+          NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed — onFailure: \(onFailure)")
           if onFailure == "skip" {
-            print("[NitroFetch][TokenRefresh] Skipping all prefetches")
+            NitroLogger.log("[NitroFetch][TokenRefresh] Skipping all prefetches")
             return
           }
           let cached = deserializeCache(
             NitroFetchSecureAtRest.decryptedString(forKey: tokenCacheKey, defaults: userDefaults))
-          print("[NitroFetch][TokenRefresh] Using cached tokens (\(cached.headers.count) header(s), \(cached.bodyFields.count) body field(s), \(cached.formFields.count) form field(s))")
+          NitroLogger.log("[NitroFetch][TokenRefresh] Using cached tokens (\(cached.headers.count) header(s), \(cached.bodyFields.count) body field(s), \(cached.formFields.count) form field(s))")
           tokens = cached
         }
       } else {
@@ -171,16 +169,14 @@ public final class NitroAutoPrefetcher: NSObject {
   }
 
   private static func startPrefetches(_ entries: [Any], tokens: TokenRefreshResult) {
-    print("[NitroFetch][TokenRefresh] Injecting tokens into \(entries.count) prefetch URL(s)")
+    NitroLogger.log("[NitroFetch][TokenRefresh] Injecting tokens into \(entries.count) prefetch URL(s)")
     for item in entries {
       guard let obj = item as? [String: Any] else { continue }
       guard let url = obj["url"] as? String, !url.isEmpty else { continue }
       guard let prefetchKey = obj["prefetchKey"] as? String, !prefetchKey.isEmpty else { continue }
 
-      print("[NitroFetch][TokenRefresh] Prefetching \(url)")
-      #if DEBUG
+      NitroLogger.log("[NitroFetch][TokenRefresh] Prefetching \(url)")
       logTokens(tokens)
-      #endif
 
       let req = buildNitroRequest(from: obj, tokens: tokens)
       Task {
@@ -279,22 +275,20 @@ public final class NitroAutoPrefetcher: NSObject {
 
   // MARK: - Token refresh
 
-  #if DEBUG
   private static func logTokens(_ tokens: TokenRefreshResult) {
     if !tokens.headers.isEmpty {
-      print("[NitroFetch][TokenRefresh]   headers:")
-      for (k, v) in tokens.headers { print("[NitroFetch][TokenRefresh]     \(k): \(v)") }
+      NitroLogger.log("[NitroFetch][TokenRefresh]   headers:")
+      for (k, v) in tokens.headers { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
     }
     if !tokens.bodyFields.isEmpty {
-      print("[NitroFetch][TokenRefresh]   body fields:")
-      for (k, v) in tokens.bodyFields { print("[NitroFetch][TokenRefresh]     \(k): \(v)") }
+      NitroLogger.log("[NitroFetch][TokenRefresh]   body fields:")
+      for (k, v) in tokens.bodyFields { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
     }
     if !tokens.formFields.isEmpty {
-      print("[NitroFetch][TokenRefresh]   form fields:")
-      for (k, v) in tokens.formFields { print("[NitroFetch][TokenRefresh]     \(k): \(v)") }
+      NitroLogger.log("[NitroFetch][TokenRefresh]   form fields:")
+      for (k, v) in tokens.formFields { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
     }
   }
-  #endif
 
   struct TokenRefreshResult {
     var headers: [String: String]

--- a/packages/react-native-nitro-fetch/ios/NitroLogger.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroLogger.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Flip `enabled` to log in release builds too.
+enum NitroLogger {
+#if DEBUG
+  static var enabled = true
+#else
+  static var enabled = false
+#endif
+
+  static func log(_ message: @autoclosure () -> String) {
+    if enabled { print(message()) }
+  }
+}

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroLogger.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroLogger.kt
@@ -1,0 +1,13 @@
+package com.margelo.nitro.nitrofetchwebsockets
+
+import android.util.Log
+
+/** Flip [enabled] to log in release builds too. */
+object NitroLogger {
+  @JvmField var enabled: Boolean = BuildConfig.DEBUG
+
+  fun d(tag: String, msg: String) { if (enabled) Log.d(tag, msg) }
+  fun i(tag: String, msg: String) { if (enabled) Log.i(tag, msg) }
+  fun w(tag: String, msg: String, t: Throwable? = null) { if (enabled) Log.w(tag, msg, t) }
+  fun e(tag: String, msg: String, t: Throwable? = null) { if (enabled) Log.e(tag, msg, t) }
+}

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -135,7 +135,7 @@ object NitroWebSocketAutoPrewarmer {
       val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
       val raw = prefs.getString(KEY_QUEUE, null) ?: return
       val arr = JSONArray(raw)
-      android.util.Log.d("NitroWS", "Auto-prewarmer starting — ${arr.length()} URL(s) in queue")
+      NitroLogger.d("NitroWS", "Auto-prewarmer starting — ${arr.length()} URL(s) in queue")
 
       val refreshRaw = NitroWSSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_REFRESH)
 
@@ -146,22 +146,22 @@ object NitroWebSocketAutoPrewarmer {
             val refreshConfig = JSONObject(refreshRaw)
             val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
             val refreshURL = refreshConfig.optString("url", "(unknown)")
-            android.util.Log.d("NitroWS", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
+            NitroLogger.d("NitroWS", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
 
             val refreshed = callTokenRefreshSync(refreshConfig)
 
             val tokenHeaders: Map<String, String> = if (refreshed != null) {
-              android.util.Log.d("NitroWS", "[TokenRefresh] ✅ Success — got ${refreshed.size} header(s)")
-              refreshed.forEach { (k, v) -> android.util.Log.d("NitroWS", "[TokenRefresh]   $k: $v") }
+              NitroLogger.d("NitroWS", "[TokenRefresh] ✅ Success — got ${refreshed.size} header(s)")
+              refreshed.forEach { (k, v) -> NitroLogger.d("NitroWS", "[TokenRefresh]   $k: $v") }
               // Cache fresh token headers for useStoredHeaders fallback on next cold start
               val cacheJson = JSONObject()
               refreshed.forEach { (k, v) -> cacheJson.put(k, v) }
               NitroWSSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, cacheJson.toString())
               refreshed
             } else {
-              android.util.Log.d("NitroWS", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
+              NitroLogger.d("NitroWS", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
               if (onFailure == "skip") {
-                android.util.Log.d("NitroWS", "[TokenRefresh] Skipping all prewarms")
+                NitroLogger.d("NitroWS", "[TokenRefresh] Skipping all prewarms")
                 return@Thread
               }
               // Use last cached token headers (or empty map if none cached yet)
@@ -174,11 +174,11 @@ object NitroWebSocketAutoPrewarmer {
               } else {
                 emptyMap()
               }
-              android.util.Log.d("NitroWS", "[TokenRefresh] Using cached headers (${cached.size} header(s))")
+              NitroLogger.d("NitroWS", "[TokenRefresh] Using cached headers (${cached.size} header(s))")
               cached
             }
 
-            android.util.Log.d("NitroWS", "[TokenRefresh] Injecting token headers into ${arr.length()} prewarm URL(s)")
+            NitroLogger.d("NitroWS", "[TokenRefresh] Injecting token headers into ${arr.length()} prewarm URL(s)")
             startPrewarms(arr, tokenHeaders)
           } catch (_: Throwable) {
             // Best-effort — never crash the app
@@ -197,7 +197,7 @@ object NitroWebSocketAutoPrewarmer {
     for (i in 0 until arr.length()) {
       val obj = arr.optJSONObject(i) ?: continue
       val url = obj.optString("url", null) ?: continue
-      android.util.Log.d("NitroWS", "Pre-warming $url")
+      NitroLogger.d("NitroWS", "Pre-warming $url")
 
       val protocols = mutableListOf<String>()
       val protocolsArr = obj.optJSONArray("protocols")
@@ -217,8 +217,8 @@ object NitroWebSocketAutoPrewarmer {
       }
       tokenHeaders.forEach { (k, v) -> merged[k] = v }
 
-      android.util.Log.d("NitroWS", "[TokenRefresh] Pre-warming $url with ${merged.size} header(s)")
-      merged.forEach { (k, v) -> android.util.Log.d("NitroWS", "[TokenRefresh]   $k: $v") }
+      NitroLogger.d("NitroWS", "[TokenRefresh] Pre-warming $url with ${merged.size} header(s)")
+      merged.forEach { (k, v) -> NitroLogger.d("NitroWS", "[TokenRefresh]   $k: $v") }
       NitroWebSocketPrewarmer.preWarm(url, protocols, merged)
     }
   }

--- a/packages/react-native-nitro-websockets/ios/NitroLogger.h
+++ b/packages/react-native-nitro-websockets/ios/NitroLogger.h
@@ -1,0 +1,19 @@
+//
+//  NitroLogger.h
+//  Flip NitroWSLoggingEnabled to log in release builds too.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+extern BOOL NitroWSLoggingEnabled;
+
+NS_INLINE void NitroWSLog(NSString *format, ...) {
+  if (!NitroWSLoggingEnabled) return;
+  va_list args;
+  va_start(args, format);
+  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+  NSLog(@"%@", message);
+}

--- a/packages/react-native-nitro-websockets/ios/NitroLogger.mm
+++ b/packages/react-native-nitro-websockets/ios/NitroLogger.mm
@@ -1,0 +1,7 @@
+#import "NitroLogger.h"
+
+#ifdef DEBUG
+BOOL NitroWSLoggingEnabled = YES;
+#else
+BOOL NitroWSLoggingEnabled = NO;
+#endif

--- a/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
+++ b/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
@@ -18,6 +18,7 @@
 #endif
 
 #include "WebSocketPrewarmer.hpp"
+#import "NitroLogger.h"
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -199,9 +200,9 @@ static void NitroWSRunPrewarmsWithTokenHeaders(NSArray *arr,
       headers[[k UTF8String]] = [v UTF8String];
     }];
 
-    NSLog(@"[NitroWS] Pre-warming %@ with %zu header(s)", url, headers.size());
+    NitroWSLog(@"[NitroWS] Pre-warming %@ with %zu header(s)", url, headers.size());
     for (auto &kv : headers) {
-      NSLog(@"[NitroWS]   %s: %s", kv.first.c_str(), kv.second.c_str());
+      NitroWSLog(@"[NitroWS]   %s: %s", kv.first.c_str(), kv.second.c_str());
     }
     margelo::nitro::nitrofetchwebsockets::WebSocketPrewarmer::instance()
       .preConnect(urlStr, protocols, headers);
@@ -228,7 +229,7 @@ static void NitroWSRunAutoPrewarm() {
     NSArray *arr = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     if (![arr isKindOfClass:[NSArray class]]) return;
 
-    NSLog(@"[NitroWS] Auto-prewarmer starting — %lu URL(s) in queue", (unsigned long)arr.count);
+    NitroWSLog(@"[NitroWS] Auto-prewarmer starting — %lu URL(s) in queue", (unsigned long)arr.count);
 
     NSString *refreshRaw = [NitroWSSecureAtRestBridge decryptedStringForKey:refreshKey suiteName:suiteName];
 
@@ -247,13 +248,13 @@ static void NitroWSRunAutoPrewarm() {
           if (![onFailure isKindOfClass:[NSString class]]) onFailure = @"useStoredHeaders";
 
           NSString *refreshURL = refreshConfig[@"url"];
-          NSLog(@"[NitroWS][TokenRefresh] Calling refresh endpoint: %@", refreshURL);
+          NitroWSLog(@"[NitroWS][TokenRefresh] Calling refresh endpoint: %@", refreshURL);
 
           NSDictionary *refreshed = NitroWSCallTokenRefreshSync(refreshConfig);
           if (refreshed) {
-            NSLog(@"[NitroWS][TokenRefresh] ✅ Success — got %lu header(s)", (unsigned long)refreshed.count);
+            NitroWSLog(@"[NitroWS][TokenRefresh] ✅ Success — got %lu header(s)", (unsigned long)refreshed.count);
             [refreshed enumerateKeysAndObjectsUsingBlock:^(NSString *k, NSString *v, BOOL *stop) {
-              NSLog(@"[NitroWS][TokenRefresh]   %@: %@", k, v);
+              NitroWSLog(@"[NitroWS][TokenRefresh]   %@: %@", k, v);
             }];
             // Cache fresh token headers
             NSData *cacheData = [NSJSONSerialization dataWithJSONObject:refreshed options:0 error:nil];
@@ -265,22 +266,22 @@ static void NitroWSRunAutoPrewarm() {
             }
             tokenHeaders = refreshed;
           } else {
-            NSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed — onFailure: %@", onFailure);
+            NitroWSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed — onFailure: %@", onFailure);
             if ([onFailure isEqualToString:@"skip"]) {
-              NSLog(@"[NitroWS][TokenRefresh] Skipping all prewarms");
+              NitroWSLog(@"[NitroWS][TokenRefresh] Skipping all prewarms");
               return;
             }
             tokenHeaders = NitroWSLoadCachedTokenHeaders(suiteName, cacheKey);
-            NSLog(@"[NitroWS][TokenRefresh] Using cached headers (%lu header(s))", (unsigned long)tokenHeaders.count);
+            NitroWSLog(@"[NitroWS][TokenRefresh] Using cached headers (%lu header(s))", (unsigned long)tokenHeaders.count);
           }
         }
 
-        NSLog(@"[NitroWS][TokenRefresh] Injecting token headers into %lu prewarm URL(s)", (unsigned long)arr.count);
+        NitroWSLog(@"[NitroWS][TokenRefresh] Injecting token headers into %lu prewarm URL(s)", (unsigned long)arr.count);
         NitroWSRunPrewarmsWithTokenHeaders(arr, tokenHeaders ?: @{});
       });
     } else {
       // No token refresh — call preConnect directly (non-blocking C++ call)
-      NSLog(@"[NitroWS] No token refresh config — prewarming without extra headers");
+      NitroWSLog(@"[NitroWS] No token refresh config — prewarming without extra headers");
       NitroWSRunPrewarmsWithTokenHeaders(arr, @{});
     }
   });


### PR DESCRIPTION
## Summary
- Adds a `NitroLogger` (nitro-fetch: Kotlin + Swift; nitro-websockets: Kotlin + ObjC++) that gates logging on a plain mutable flag, defaulting to enabled in debug builds and disabled in release
- Replaces all direct `Log.d/i/w/e`, `NSLog`, and `print` calls in product code (nitro-fetch, nitro-websockets) with calls through `NitroLogger` — no behavior change in debug, silences release logging by default while still letting consumers flip the flag on

## Test plan
- [ ] CI passes (Android build, iOS build, lint/typecheck)