### PR TITLE
fix: stop tsc emitting compiled .js into src/

### DIFF
--- a/packages/react-native-nitro-fetch/tsconfig.build.json
+++ b/packages/react-native-nitro-fetch/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+    "noEmit": false
+  },
   "exclude": ["example", "lib"]
 }

--- a/packages/react-native-nitro-fetch/tsconfig.json
+++ b/packages/react-native-nitro-fetch/tsconfig.json
@@ -18,6 +18,7 @@
     ],
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,


### PR DESCRIPTION
Fixes #143.

## The short version

`bun typecheck` doesn't only typecheck — it emits. Run it and then `bun lint`, the order CONTRIBUTING.md gives, and lint fails with 1868 errors in files you never touched.

One line fixes it:

```jsonc
// packages/react-native-nitro-fetch/tsconfig.json
"noEmit": true,
```

## The cause

`tsconfig.json` set neither `noEmit` nor `outDir`, so bare `tsc` emitted compiled `.js` next to every source in `src/`. The real build goes to `lib/` via builder-bob, so none of that output was wanted.

CI never caught it because `ci.yml` lints *before* it typechecks, on a fresh checkout. `lefthook.yml` already passes `--noEmit` explicitly for its pre-commit typecheck, so the flag was clearly intended — the `typecheck` script just missed it.

## Why tsconfig.build.json changed too

`tsconfig.build.json` extends `./tsconfig`, so it inherits the new `noEmit: true` — and it's the config bob builds from. I've overridden it back to `false` there.

To be clear about what that's doing: bob passes its own emit flags to tsc, so I verified `bun prepare` produces `lib/typescript/**/*.d.ts` correctly **with or without** this override. It isn't load-bearing. I kept it because a config named `build` that inherits `noEmit: true` is a trap for anyone running `tsc -p tsconfig.build.json` directly, and it means the build doesn't silently depend on bob's CLI flags. Happy to drop those three lines if you'd rather keep the diff at one.

## What I checked

- `bun typecheck` — passes, and emits nothing now (`git status` stays clean)
- `bun lint` — passes after a typecheck, which is the whole point
- `bun test` — 12 tests across 3 files, 0 fail
- `bun prepare` — bob still writes `lib/module` and `lib/typescript`, declarations intact
- `bun fetch build:plugin` — unaffected (`expo/plugins/tsconfig.json` extends `expo-module-scripts`, not this config)

## Still open from the issue, not done here

- `src/__tests__/index.test.js` is tracked and looks like a committed instance of this same bug — it's `index.test.tsx` plus a `'use strict'` line, and it makes those tests run twice. Left it alone since deleting a tracked test felt like your call.
- The `!packages/**/src/**/*.test.js` negation in `.gitignore` is what let the generated test output through. Harmless once tsc stops emitting, so I left it.

Say the word on either and I'll fold them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
