### PR TITLE
fix(ios): preserve URLSession delegate compatibility

### DIFF
--- a/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
@@ -11,7 +11,7 @@ class HybridNitroCronet: HybridNitroCronetSpec {
       diskCapacity: 100 * 1024 * 1024,
       diskPath: "nitrofetch_urlcache"
     )
-    return URLSession(configuration: config)
+    return NitroURLSession.make(configuration: config)
   }()
 
   // Shared executor queue

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -314,7 +314,7 @@ public final class NitroAutoPrefetcher: NSObject {
       request.httpBody = body.data(using: .utf8)
     }
 
-    let (data, response) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await NitroURLSession.shared.data(for: request)
     guard let http = response as? HTTPURLResponse,
           (200...299).contains(http.statusCode) else {
       throw NSError(domain: "NitroAutoPrefetcher", code: -2,

--- a/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroFetchClient.swift
@@ -104,7 +104,7 @@ final class NitroFetchClient: HybridNitroFetchClientSpec {
     config.urlCache = URLCache(memoryCapacity: 32 * 1024 * 1024,
                                diskCapacity: 100 * 1024 * 1024,
                                diskPath: "nitrofetch_urlcache")
-    return URLSession(configuration: config)
+    return NitroURLSession.make(configuration: config)
   }()
 
   private static func findPrefetchKey(_ req: NitroRequest) -> String? {

--- a/packages/react-native-nitro-fetch/ios/NitroURLSession.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroURLSession.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Keeps authentication challenges observable by delegate-based networking middleware.
+private final class NitroURLSessionDelegate: NSObject, URLSessionDelegate {}
+
+enum NitroURLSession {
+  static let shared = make(configuration: .default)
+
+  static func make(configuration: URLSessionConfiguration) -> URLSession {
+    return URLSession(
+      configuration: configuration,
+      delegate: NitroURLSessionDelegate(),
+      delegateQueue: nil
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- create NitroFetch's internal iOS URLSessions with an inert, non-nil delegate
- use the delegated sessions for normal fetches, prefetches, and token refreshes
- preserve the existing purpose-built delegate used by streaming requests

## Why

NitroFetch currently uses `URLSession(configuration:)` and `URLSession.shared` for some request paths. Those sessions do not provide an application delegate for delegate-swizzling networking middleware to proxy, so middleware that observes authentication challenges (for example, TrustKit certificate pinning) cannot validate those requests.

The new delegate implements no callbacks, so URLSession keeps its default TLS and networking behavior when no middleware is installed. This change only preserves the standard delegate integration point; it does not add certificate pinning or a new dependency to NitroFetch.

## Test plan

- `nr typecheck`
- focused Jest package tests
- built the `NitroFetch` CocoaPods target for a generic iOS Simulator with Xcode 26.6
- audited iOS URLSession construction: all network request paths now have a session delegate, while streaming retains its existing request delegate
