### PR TITLE
fix: support AbortSignal for streamed responses

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -546,6 +546,49 @@ describe('NitroFetch - real HTTPS (PokeAPI)', () => {
 });
 
 describe('NitroFetch - Streaming', () => {
+  it('pre-aborted streamed request rejects with AbortError', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let threw = false;
+
+    try {
+      await (nitroFetch as any)(`${BASE}/drip?duration=0&numbytes=1&delay=0`, {
+        stream: true,
+        signal: controller.signal,
+      });
+    } catch (error: any) {
+      threw = true;
+      expect(error.name).toBe('AbortError');
+    }
+
+    expect(threw).toBe(true);
+  });
+
+  it('aborting after the first /drip chunk rejects the next read with AbortError', async () => {
+    const controller = new AbortController();
+    const res = (await (nitroFetch as any)(
+      `${BASE}/drip?duration=5&numbytes=5&delay=0`,
+      { stream: true, signal: controller.signal }
+    )) as any;
+    const readable = res.body?.getReader?.();
+    expect(readable).toBeDefined();
+
+    const first = await readable.read();
+    expect(first.done).toBe(false);
+    expect(first.value?.byteLength).toBeGreaterThan(0);
+
+    controller.abort();
+    let threw = false;
+    try {
+      await readable.read();
+    } catch (error: any) {
+      threw = true;
+      expect(error.name).toBe('AbortError');
+    }
+
+    expect(threw).toBe(true);
+  });
+
   it('streams JSON lines from /stream/5 and produces non-empty text', async () => {
     const res = (await (nitroFetch as any)(`${BASE}/stream/5`, {
       stream: true,

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -762,6 +762,11 @@ async function nitroStreamFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
+  const signal = init?.signal as AbortSignal | undefined | null;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
   const url = getUrlString(input);
   const src = input as { method?: string; headers?: HeadersInit };
   const method = (init?.method ?? src?.method)?.toUpperCase() ?? 'GET';
@@ -795,6 +800,13 @@ async function nitroStreamFetch(
     let streamController: ReadableStreamDefaultController<
       Uint8Array<ArrayBuffer>
     >;
+    let abortListener: (() => void) | undefined;
+
+    const cleanupAbortListener = () => {
+      if (!signal || !abortListener) return;
+      signal.removeEventListener('abort', abortListener);
+      abortListener = undefined;
+    };
 
     const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
       start(controller) {
@@ -806,7 +818,7 @@ async function nitroStreamFetch(
     let streamBytesReceived = 0;
 
     builder.onResponseStarted((info) => {
-      if (responseResolved) return;
+      if (responseResolved || signal?.aborted) return;
       responseResolved = true;
       const status = info.httpStatusCode;
       const responseHeaders = new NitroHeaders(
@@ -828,6 +840,7 @@ async function nitroStreamFetch(
     });
 
     builder.onReadCompleted((_info, byteBuffer, bytesRead) => {
+      if (signal?.aborted) return;
       const chunk = new Uint8Array(byteBuffer, 0, bytesRead).slice();
       streamBytesReceived += bytesRead;
       streamController.enqueue(chunk);
@@ -837,6 +850,7 @@ async function nitroStreamFetch(
     });
 
     builder.onSucceeded((_info) => {
+      cleanupAbortListener();
       streamController.close();
       if (inspectorId) {
         const info = _info as any;
@@ -853,7 +867,10 @@ async function nitroStreamFetch(
     });
 
     builder.onFailed((_info, error) => {
-      const err = new Error(error.message);
+      cleanupAbortListener();
+      const err = signal?.aborted
+        ? createAbortError()
+        : new Error(error.message);
       if (inspectorId) {
         NetworkInspector._recordEnd(inspectorId, 0, '', [], 0, error.message);
       }
@@ -866,6 +883,7 @@ async function nitroStreamFetch(
     });
 
     builder.onCanceled(() => {
+      cleanupAbortListener();
       const err = createAbortError();
       if (inspectorId) {
         NetworkInspector._recordEnd(
@@ -886,6 +904,16 @@ async function nitroStreamFetch(
     });
 
     const request = builder.build();
+    if (signal) {
+      abortListener = () => {
+        try {
+          request.cancel();
+        } catch {
+          return;
+        }
+      };
+      signal.addEventListener('abort', abortListener, { once: true });
+    }
     request.start();
   });
 }


### PR DESCRIPTION
refs #149

wires `AbortSignal` into streamed requests and covers pre-abort + mid-stream cancellation in the device harness. leaves `response.body.cancel()` for a separate tested change.

testing: ios harness 47/47; typecheck, lint, and unit tests pass. android not run locally.
