### PR TITLE
fix(ios): share URLCache across fetch transports

### DIFF
--- a/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
@@ -6,11 +6,7 @@ class HybridNitroCronet: HybridNitroCronetSpec {
   private static let session: URLSession = {
     let config = URLSessionConfiguration.default
     config.requestCachePolicy = .useProtocolCachePolicy
-    config.urlCache = URLCache(
-      memoryCapacity: 32 * 1024 * 1024,
-      diskCapacity: 100 * 1024 * 1024,
-      diskPath: "nitrofetch_urlcache"
-    )
+    config.urlCache = NitroURLCache.shared
     return NitroURLSession.make(configuration: config)
   }()
 

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -101,9 +101,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
   private static let session: URLSession = {
     let config = URLSessionConfiguration.default
     config.requestCachePolicy = .useProtocolCachePolicy
-    config.urlCache = URLCache(memoryCapacity: 32 * 1024 * 1024,
-                               diskCapacity: 100 * 1024 * 1024,
-                               diskPath: "nitrofetch_urlcache")
+    config.urlCache = NitroURLCache.shared
     return NitroURLSession.make(configuration: config)
   }()
 

--- a/packages/react-native-nitro-fetch/ios/NitroURLSession.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroURLSession.swift
@@ -3,6 +3,14 @@ import Foundation
 /// Keeps authentication challenges observable by delegate-based networking middleware.
 private final class NitroURLSessionDelegate: NSObject, URLSessionDelegate {}
 
+enum NitroURLCache {
+  static let shared = URLCache(
+    memoryCapacity: 32 * 1024 * 1024,
+    diskCapacity: 100 * 1024 * 1024,
+    diskPath: "nitrofetch_urlcache"
+  )
+}
+
 enum NitroURLSession {
   static let shared = make(configuration: .default)
 


### PR DESCRIPTION
## Summary

- use one internal iOS `URLCache` for standard and streaming fetch sessions
- preserve the existing 32 MiB memory capacity, 100 MiB disk capacity, disk path, and protocol cache policy

## Why

Both iOS transports currently create separate `URLCache` objects backed by the same `nitrofetch_urlcache` disk path. Sharing one cache keeps memory and disk cache ownership consistent and makes lifecycle behavior unambiguous without disabling or clearing caching.

Closes #156

## Validation

- `xcrun swiftc -parse` for all changed Swift files
- `bun lint` (passes with two existing no-shadow warnings)
- `bun typecheck`
- `bun test --maxWorkers=2`
- commit hooks