### PR TITLE
feat: add tvOS build support

### DIFF
--- a/packages/react-native-nitro-fetch/NitroFetch.podspec
+++ b/packages/react-native-nitro-fetch/NitroFetch.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported }
   s.source       = { :git => "http://google.com.git", :tag => "#{s.version}" }
 
 

--- a/packages/react-native-nitro-text-decoder/NitroTextDecoder.podspec
+++ b/packages/react-native-nitro-text-decoder/NitroTextDecoder.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [

--- a/packages/react-native-nitro-websockets/NitroFetchWebsockets.podspec
+++ b/packages/react-native-nitro-websockets/NitroFetchWebsockets.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [


### PR DESCRIPTION
## Summary
- add `tvos` target to each package podfile
- supersedes #93

## Why
Without adding the podfile target, Nitro Fetch can't be built for tvOS. As I mentioned [in Discord](https://discord.com/channels/1147256486762913884/1419702335503863808/1533592044079943900), my team is already using these patches in production, at scale without issue. tvOS is functionally identical to iOS on the URLSession side of things, so no further changes are needed to the library for everything to Just Work™.

One thing to note (and discussed already in Discord), RN doesn't provide a tvOS-specific version helper, so I've just re-used the `min_ios_version_supported` value. This is safe because tvOS is updated in lock-step with iOS. It's also a pattern used by other libraries, for example [react-native-ease](https://github.com/appandflow/react-native-ease/blob/0117d95db288a69add5f177e3f69abfd75c5c3f3/Ease.podspec#L13).