### PR TITLE
#152 : Fix - Opt out of dev tools reporting 

### DIFF
--- a/docs-website/docs/inspection.md
+++ b/docs-website/docs/inspection.md
@@ -6,7 +6,7 @@ sidebar_position: 9
 
 # Network Inspection
 
-Nitro Fetch ships with a built-in **NetworkInspector** that records HTTP and WebSocket activity at the JS level, and native **Perfetto / Instruments tracing** for zero-overhead profiling in production.
+Nitro Fetch ships with a built-in **NetworkInspector** that records HTTP and WebSocket activity at the JS level, reports requests to the **React Native DevTools** Network panel in debug builds, and emits native **Perfetto / Instruments traces** for zero-overhead profiling in production.
 
 ## JS Network Inspector
 
@@ -169,6 +169,38 @@ export function NetworkDebugger() {
 :::tip
 The example app includes a full-featured inspector screen with filter tabs (All / HTTP / WS), detail views, curl export, and a live log console. See [`example/src/screens/NetworkInspectorScreen.tsx`](https://github.com/margelo/react-native-nitro-fetch/blob/main/example/src/screens/NetworkInspectorScreen.tsx) for the complete implementation.
 :::
+
+---
+
+## React Native DevTools Network panel
+
+In **debug builds only**, Nitro Fetch reports each request to the React Native DevTools **Network** panel natively — through `InspectorNetworkReporter` on Android and `RCTInspectorNetworkReporter` (RN 0.83+) on iOS. This is on by default and needs no setup. In release builds the whole path is compiled out.
+
+### Opting out
+
+If another tool already reports the same traffic, every request shows up twice. The usual case is **`expo-dev-client` on iOS**: it swizzles `URLSessionConfiguration.default`, which Nitro Fetch's `URLSession` is built from, so expo-dev-launcher reports the request over its own CDP socket while Nitro Fetch reports the same request through `RCTInspectorNetworkReporter`.
+
+Turn Nitro Fetch's native reporting off at build time:
+
+#### Android
+
+Add to your app's `gradle.properties`, then rebuild:
+
+```properties
+NitroFetch_disableDevToolsReporting=true
+```
+
+#### iOS
+
+Set the environment variable **before** running `pod install`:
+
+```bash
+NITROFETCH_DISABLE_DEVTOOLS_REPORTING=1 bundle exec pod install
+```
+
+Then rebuild. Run `pod install` explicitly when flipping this flag — `npx expo run:ios` and `yarn ios` skip it when the `Podfile` hasn't changed, so the flag would otherwise appear to have no effect.
+
+
 
 ---
 

--- a/packages/react-native-nitro-fetch/NitroFetch.podspec
+++ b/packages/react-native-nitro-fetch/NitroFetch.podspec
@@ -39,5 +39,13 @@ Pod::Spec.new do |s|
     })
   end
 
+  if ENV['NITROFETCH_DISABLE_DEVTOOLS_REPORTING'] == '1'
+    current_xcconfig = s.attributes_hash['pod_target_xcconfig'] || {}
+    existing = current_xcconfig['GCC_PREPROCESSOR_DEFINITIONS'] || '$(inherited)'
+    s.pod_target_xcconfig = current_xcconfig.merge({
+      'GCC_PREPROCESSOR_DEFINITIONS' => "#{existing} NITROFETCH_DISABLE_DEVTOOLS_REPORTING=1"
+    })
+  end
+
   install_modules_dependencies(s)
 end

--- a/packages/react-native-nitro-fetch/android/build.gradle
+++ b/packages/react-native-nitro-fetch/android/build.gradle
@@ -42,6 +42,9 @@ android {
     def enableTracing = (getExtOrDefault("enableTracing") ?: "false").toString().toBoolean()
     buildConfigField "boolean", "NITRO_FETCH_TRACING", enableTracing.toString()
 
+    def disableDevToolsReporting = (getExtOrDefault("disableDevToolsReporting") ?: "false").toString().toBoolean()
+    buildConfigField "boolean", "NITRO_FETCH_DISABLE_DEVTOOLS_REPORTING", disableDevToolsReporting.toString()
+
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -fstack-protector-all"

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -120,7 +120,11 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       // && so every `if (devToolsEnabled)` block below becomes dead code and
       // the DevToolsReporter classes drop out of the release APK entirely.
       // The UUID generation is gated too so SecureRandom isn't touched in release.
-      val devToolsEnabled = BuildConfig.DEBUG && DevToolsReporter.isDebuggingEnabled()
+      // Opt out via `NitroFetch_disableDevToolsReporting=true` in gradle.properties
+      //  Avoids double-logging with expo-dev-client
+      val devToolsEnabled = BuildConfig.DEBUG &&
+        !BuildConfig.NITRO_FETCH_DISABLE_DEVTOOLS_REPORTING &&
+        DevToolsReporter.isDebuggingEnabled()
       val devToolsRequestId = if (devToolsEnabled) (req.requestId ?: UUID.randomUUID().toString()) else ""
       val callback = object : UrlRequest.Callback() {
         private val buffer = ByteBuffer.allocateDirect(16 * 1024)

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridUrlRequestBuilder.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridUrlRequestBuilder.kt
@@ -29,7 +29,11 @@ class HybridUrlRequestBuilder(
   private val byteBuffer: ByteBuffer
   // BuildConfig.DEBUG short-circuits in release so R8 strips DevTools paths.
   // UUID generation is gated too so SecureRandom isn't touched in release.
-  private val devToolsEnabled: Boolean = BuildConfig.DEBUG && DevToolsReporter.isDebuggingEnabled()
+  // Opt out via `NitroFetch_disableDevToolsReporting=true` in gradle.properties
+  //  Avoids double-logging with expo-dev-client
+  private val devToolsEnabled: Boolean = BuildConfig.DEBUG &&
+    !BuildConfig.NITRO_FETCH_DISABLE_DEVTOOLS_REPORTING &&
+    DevToolsReporter.isDebuggingEnabled()
   private val devToolsRequestId: String = if (devToolsEnabled) UUID.randomUUID().toString() else ""
   private var devToolsBytes: Int = 0
   private var devToolsTextual: Boolean = false

--- a/packages/react-native-nitro-fetch/ios/NitroDevToolsReporter.mm
+++ b/packages/react-native-nitro-fetch/ios/NitroDevToolsReporter.mm
@@ -40,7 +40,13 @@
   return available;
 }
 
+// Opting out here — rather than in +isDebuggingEnabled — makes every entry point below a no-op,
+// since they all resolve the class through here. Set NITROFETCH_DISABLE_DEVTOOLS_REPORTING=1
+// before `pod install` to avoid double-logging with expo-dev-client.
 + (Class _Nullable)reporterClass {
+#if defined(NITROFETCH_DISABLE_DEVTOOLS_REPORTING)
+  return Nil;
+#else
   if (![self reporterAPIAvailable]) {
     return Nil;
   }
@@ -50,14 +56,11 @@
     cached = NSClassFromString(@"RCTInspectorNetworkReporter");
   });
   return cached;
+#endif
 }
 
 + (BOOL)isDebuggingEnabled {
-#if defined(NITROFETCH_DISABLE_DEVTOOLS_REPORTING)
-  return NO;
-#else
   return [self reporterClass] != Nil;
-#endif
 }
 
 + (void)reportRequestStartWithRequest:(NSString *)requestId

--- a/packages/react-native-nitro-fetch/ios/NitroDevToolsReporter.mm
+++ b/packages/react-native-nitro-fetch/ios/NitroDevToolsReporter.mm
@@ -53,7 +53,11 @@
 }
 
 + (BOOL)isDebuggingEnabled {
+#if defined(NITROFETCH_DISABLE_DEVTOOLS_REPORTING)
+  return NO;
+#else
   return [self reporterClass] != Nil;
+#endif
 }
 
 + (void)reportRequestStartWithRequest:(NSString *)requestId


### PR DESCRIPTION
Fixes #152 : requests were showing up twice in the DevTools Network tab when expo-dev-client is installed, because both Nitro Fetch's own CDP reporter and expo-dev-client's URLSessionConfiguration.default interceptor report the same request independently.

Adds a **build-time opt-out** for Nitro Fetch's native DevTools network reporting ,using gradle.properties for Android and  driven an environment variable for iOS. Approach is somewhat similar to the existing enableTracing / NITROFETCH_TRACING flag used.

- **Android** : NitroFetch_disableDevToolsReporting=true in gradle.properties → BuildConfig.NITRO_FETCH_DISABLE_DEVTOOLS_REPORTING used in the existing devToolsEnabled check in HybridNitroFetchClient.kt and HybridUrlRequestBuilder.kt .
- **iOS** : setting NITROFETCH_DISABLE_DEVTOOLS_REPORTING=1 before pod install passes a compile-time flag into the native build where thereafter, NitroFetch.podspec (injects the flag) and ios/NitroDevToolsReporter.mm (checks it in isDebuggingEnabled to turn off reporting at its single source)

By default this flag will be false.