### PR TITLE
fix: stop sending the internal prefetchKey header to the server

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -650,3 +650,43 @@ describe('NitroFetch - Streaming', () => {
     expect(total).toBe(numBytes);
   });
 });
+
+it('never sends prefetchKey to the server on any request path', async () => {
+  const url = `${BASE}/headers`;
+  const key = `harness-strip-${String(Date.now())}`;
+  const init = {
+    headers: { 'prefetchKey': key, 'X-Nitro-Test': 'keep' },
+    prefetchCacheTtlMs: 60_000,
+  } as any;
+  const sentKeys = (json: any): string[] =>
+    Object.keys(json.headers ?? {}).map((k) => k.toLowerCase());
+
+  const plain = await nitroFetch(url, init);
+  expect(plain.ok).toBe(true);
+  expect(sentKeys(await plain.json())).not.toContain('prefetchkey');
+
+  const streamed = (await (nitroFetch as any)(url, {
+    ...init,
+    stream: true,
+  })) as any;
+  const reader = streamed.body.getReader();
+  const decoder = new (require('react-native-nitro-text-decoder').TextDecoder)();
+  let text = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) text += decoder.decode(value, { stream: true });
+  }
+  expect(sentKeys(JSON.parse(text))).not.toContain('prefetchkey');
+
+  await prefetch(url, init);
+  const cached = await nitroFetch(url, init);
+  expect(cached.headers.get('nitroPrefetched')).toBe('true');
+  // Body echoes the prefetch's own outbound request.
+  const cachedKeys = sentKeys(await cached.json());
+  expect(cachedKeys).not.toContain('prefetchkey');
+  expect(cachedKeys).toContain('x-nitro-test');
+
+  await removeFromAutoPrefetch(key);
+});
+

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -279,7 +279,14 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       val builder = engine.newUrlRequestBuilder(url, callback, executor)
       val method = req.method?.name ?: "GET"
       builder.setHttpMethod(method)
-      req.headers?.forEach { (k, v) -> builder.addHeader(k, v) }
+      // `prefetchKey` is an internal cache key, not a request header — every
+      // caller that needs it has already read it off the original NitroRequest
+      // via findPrefetchKey() before reaching this point, so it must not go out
+      // on the wire.
+      req.headers?.forEach { (k, v) ->
+        if (k.equals("prefetchKey", ignoreCase = true)) return@forEach
+        builder.addHeader(k, v)
+      }
 
       if (!omitCredentials) {
         NitroCookieSync.attachCookieFromManagerIfMissing(

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -279,10 +279,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       val builder = engine.newUrlRequestBuilder(url, callback, executor)
       val method = req.method?.name ?: "GET"
       builder.setHttpMethod(method)
-      // `prefetchKey` is an internal cache key, not a request header — every
-      // caller that needs it has already read it off the original NitroRequest
-      // via findPrefetchKey() before reaching this point, so it must not go out
-      // on the wire.
+      // prefetchKey is an internal cache key, never sent on the server
       req.headers?.forEach { (k, v) ->
         if (k.equals("prefetchKey", ignoreCase = true)) return@forEach
         builder.addHeader(k, v)

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -345,10 +345,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     var r = URLRequest(url: url)
     if let m = req.method?.rawValue { r.httpMethod = reqToHttpMethod(req) }
     if let headers = req.headers {
-      // `prefetchKey` is an internal cache key, not a request header — every
-      // caller that needs it has already read it off the original NitroRequest
-      // via findPrefetchKey() before reaching this point, so it must not go out
-      // on the wire.
+      // prefetchKey is an internal cache key, never sent on the server
       for h in headers where h.key.caseInsensitiveCompare("prefetchKey") != .orderedSame {
         r.addValue(h.value, forHTTPHeaderField: h.key)
       }

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -345,7 +345,13 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     var r = URLRequest(url: url)
     if let m = req.method?.rawValue { r.httpMethod = reqToHttpMethod(req) }
     if let headers = req.headers {
-      for h in headers { r.addValue(h.value, forHTTPHeaderField: h.key) }
+      // `prefetchKey` is an internal cache key, not a request header — every
+      // caller that needs it has already read it off the original NitroRequest
+      // via findPrefetchKey() before reaching this point, so it must not go out
+      // on the wire.
+      for h in headers where h.key.caseInsensitiveCompare("prefetchKey") != .orderedSame {
+        r.addValue(h.value, forHTTPHeaderField: h.key)
+      }
     }
     if let parts = req.bodyFormData, !parts.isEmpty {
       let (body, contentType) = try await buildMultipartBody(parts)

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -799,7 +799,13 @@ async function nitroStreamFetch(
   const builder = NitroCronetSingleton.newUrlRequestBuilder(url);
   builder.setHttpMethod(method);
   if (init?.credentials === 'omit') builder.disableCookies();
-  headers.forEach((h) => builder.addHeader(h.key, h.value));
+  // `prefetchKey` is an internal cache key, not a request header. The streaming
+  // path does not consult the prefetch cache at all, so it is inert here — but a
+  // caller reusing a request shape that carries it should not have it sent.
+  headers.forEach((h) => {
+    if (h.key.toLowerCase() === 'prefetchkey') return;
+    builder.addHeader(h.key, h.value);
+  });
 
   if (normalized?.bodyBytes) builder.setUploadBody(normalized.bodyBytes);
   else if (normalized?.bodyString != null)

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -799,9 +799,7 @@ async function nitroStreamFetch(
   const builder = NitroCronetSingleton.newUrlRequestBuilder(url);
   builder.setHttpMethod(method);
   if (init?.credentials === 'omit') builder.disableCookies();
-  // `prefetchKey` is an internal cache key, not a request header. The streaming
-  // path does not consult the prefetch cache at all, so it is inert here — but a
-  // caller reusing a request shape that carries it should not have it sent.
+  // prefetchKey is an internal cache key, never sent on the server
   headers.forEach((h) => {
     if (h.key.toLowerCase() === 'prefetchkey') return;
     builder.addHeader(h.key, h.value);


### PR DESCRIPTION
Addresses #166.

### What

`prefetchKey` is the library's internal cache key, but nothing removed it from the request before dispatch, so it was transmitted to the server on every request using the prefetch feature. This skips it at the three points where headers are attached to an outgoing request:

- `HybridNitroFetchClient.kt` — the Cronet builder loop.
- `HybridNitroFetchClient.swift` — `buildURLRequest`.
- `src/fetch.ts` — the streaming path (`nitroStreamFetch`), which uses the low-level `newUrlRequestBuilder` rather than either of the above.

The comparison is case-insensitive on all three, matching what `findPrefetchKey` already does.

### Why this cannot break prefetch matching

Every consumer reads the key off the original `NitroRequest` before the outgoing request is built — `findPrefetchKey()` in `requestSync` / `request` / `prefetch` on Android and in `requestStatic` / `prefetchStatic` on iOS. `AutoPrefetcher` / `NitroAutoPrefetcher` read it from the stored queue entry, not from the built request. Nothing reads it back off the wire.

Note that this is technically a behaviour change for anyone whose backend was reading the header. That seems unlikely given it is documented as a cache key, but flagging it rather than burying it — see #166 for the reasoning, including the streaming-path judgement call.

### Testing

Ran:

- `bun typecheck` — clean.
- `bun lint` — clean; the 2 warnings are pre-existing `no-shadow` warnings in the two `expo/plugins/src/withAndroid.ts` files, untouched here.
- `bun test` — 10 pass, 2 todo, 0 fail.
- `./gradlew :react-native-nitro-fetch:compileDebugKotlin` from `example/android` — `BUILD SUCCESSFUL`.
- `swiftc -parse ios/HybridNitroFetchClient.swift` — clean.

Did not run:

- The example app on either platform, so I have not watched the header disappear from a live request here. The straightforward check would be `fetch('https://httpbin.org/headers', { headers: { prefetchKey: 'x' } })` before and after; happy to add that to the example app or the harness if you would like it covered.
- iOS is parse-checked only, not compiled against the pod.

The equivalent change has been running in a production Android app, verified on a real device: prefetch hits still resolve from cache (`nitroPrefetched: true`) with the header no longer going out.

Note for anyone reproducing the baseline: `bun run test` (Jest) fails 12 suites on a clean checkout of `main` at `9ad3674`, independently of this branch — `bun test` (Bun's runner) is what passes.
