### PR TITLE
fix: import web-streams-polyfill via concrete dist path

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -492,7 +492,9 @@ describe('NitroFetch - AbortController', () => {
 });
 
 describe('NitroFetch - nitroFetchOnWorklet', () => {
-  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(['bitcoin'].join(','))}&vs_currencies=usd`;
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(
+    ['bitcoin'].join(',')
+  )}&vs_currencies=usd`;
   const mapper = (payload: { bodyString?: string }) => {
     'worklet';
     const txt = payload.bodyString ?? '';
@@ -670,7 +672,8 @@ it('never sends prefetchKey to the server on any request path', async () => {
     stream: true,
   })) as any;
   const reader = streamed.body.getReader();
-  const decoder = new (require('react-native-nitro-text-decoder').TextDecoder)();
+  const decoder =
+    new (require('react-native-nitro-text-decoder').TextDecoder)();
   let text = '';
   while (true) {
     const { done, value } = await reader.read();
@@ -689,4 +692,3 @@ it('never sends prefetchKey to the server on any request path', async () => {
 
   await removeFromAutoPrefetch(key);
 });
-

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -1,4 +1,5 @@
-import 'web-streams-polyfill/polyfill';
+// Concrete path so Metro resolves it even with unstable_enablePackageExports: false (#103).
+import 'web-streams-polyfill/dist/polyfill.js';
 import type {
   NitroFetch as NitroFetchModule,
   NitroFormDataPart,


### PR DESCRIPTION
Closes #103.

## Problem

`web-streams-polyfill@4` exposes `./polyfill` only through its `exports` map — there is no `polyfill` file or directory at the package root. Apps that set `unstable_enablePackageExports: false` in Metro (a common escape hatch) make Metro fall back to filesystem resolution, so `import 'web-streams-polyfill/polyfill'` fails inside `fetch.ts`:

```
Unable to resolve "web-streams-polyfill/polyfill" from "node_modules/react-native-nitro-fetch/src/fetch.ts"
```

Root cause diagnosed by @entropyconquers in #103.

## Fix

Import the concrete path instead:

```diff
- import 'web-streams-polyfill/polyfill';
+ import 'web-streams-polyfill/dist/polyfill.js';
```

This resolves under **both** modes:
- exports on: `"./dist/*": "./dist/*"` is in the exports map (verified via `require.resolve`)
- exports off: `node_modules/web-streams-polyfill/dist/polyfill.js` exists on disk

It also resolves if a project ends up with v3 hoisted, where `dist/polyfill.js` exists too.

Also includes a prettier fix in `nitrofetch.harness.ts` that was failing `bun lint` on main.

## Testing

- `bun typecheck` clean
- `bun lint` clean (2 pre-existing `no-shadow` warnings)
- `bun test` 10 pass, 2 todo