### PR TITLE
fix(android): align nitro-fetch NDK version

### DIFF
--- a/packages/react-native-nitro-fetch/android/build.gradle
+++ b/packages/react-native-nitro-fetch/android/build.gradle
@@ -33,6 +33,7 @@ def getExtOrIntegerDefault(name) {
 android {
   namespace "com.margelo.nitro.nitrofetch"
 
+  ndkVersion getExtOrDefault("ndkVersion")
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {


### PR DESCRIPTION
## Summary

- configure the `react-native-nitro-fetch` Android library with the consuming root project's `ndkVersion`
- fall back to the existing `NitroFetch_ndkVersion` package property when the root does not override it
- match the configuration already used by the WebSocket and text-decoder sibling packages

Fixes #178.

## Verification

The same Gradle model probe was run before and after the change:

```text
before: NITRO_FETCH_NDK_VERSION=27.0.12077973
after:  NITRO_FETCH_NDK_VERSION=27.1.12297006
```

Additional checks:

- `bun test` — 10 passed, 2 existing TODOs
- `bun typecheck`
- `bun lint` — no errors (2 existing no-shadow warnings in unrelated Expo plugin files)
- `./gradlew :react-native-nitro-fetch:assembleDebug -PreactNativeArchitectures=arm64-v8a` — successful
- generated CMake cache points to NDK `27.1.12297006`
- `llvm-readelf -Ws libnitrofetch.so` contains no `__cxa_init_primary_exception` reference
