### PR TITLE
fix(websockets): build package entrypoints before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Build package
         run: bun prepare
 
+      - name: Verify WebSocket package entrypoints
+        run: |
+          bun websockets clean
+          node scripts/verify-package-entrypoints.mjs packages/react-native-nitro-websockets
+
   build-android:
     runs-on: ubuntu-latest
     env:

--- a/packages/react-native-nitro-websockets/package.json
+++ b/packages/react-native-nitro-websockets/package.json
@@ -77,7 +77,7 @@
     "build:plugin": "cd expo/plugins && npx tsc",
     "release": "npm run build:plugin && release-it --only-version",
     "specs": "tsc --noEmit false && nitrogen --logLevel=\"debug\"",
-    "prepack": "cp ../../README.md ./README.md",
+    "prepack": "tsc --build --force && bun run build:plugin && cp ../../README.md ./README.md",
     "postpack": "rm -f ./README.md"
   },
   "keywords": [

--- a/scripts/verify-package-entrypoints.mjs
+++ b/scripts/verify-package-entrypoints.mjs
@@ -1,0 +1,65 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const packageDirectory = resolve(process.argv[2] ?? '')
+const packageJson = JSON.parse(
+  readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
+)
+
+const packDirectory = mkdtempSync(join(tmpdir(), 'verify-package-entrypoints-'))
+const packResult = spawnSync(
+  'npm',
+  ['pack', '--json', '--pack-destination', packDirectory, '--silent'],
+  {
+    cwd: packageDirectory,
+    encoding: 'utf8',
+  }
+)
+
+rmSync(packDirectory, { recursive: true, force: true })
+
+if (packResult.status !== 0) {
+  process.stderr.write(packResult.stderr)
+  process.exit(packResult.status ?? 1)
+}
+
+const [{ files }] = JSON.parse(packResult.stdout)
+const packedFiles = new Set(files.map(({ path }) => path))
+const entrypoints = new Set()
+
+function collectEntrypoints(value) {
+  if (typeof value === 'string') {
+    entrypoints.add(value.replace(/^\.\//, ''))
+    return
+  }
+
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach(collectEntrypoints)
+  }
+}
+
+collectEntrypoints(packageJson.main)
+collectEntrypoints(packageJson.module)
+collectEntrypoints(packageJson.types)
+collectEntrypoints(packageJson['react-native'])
+collectEntrypoints(packageJson.source)
+collectEntrypoints(packageJson.exports)
+
+const extensions = ['', '.js', '.jsx', '.ts', '.tsx', '.d.ts']
+const missingEntrypoints = [...entrypoints].filter(
+  (entrypoint) =>
+    !extensions.some((extension) => packedFiles.has(`${entrypoint}${extension}`))
+)
+
+if (missingEntrypoints.length > 0) {
+  console.error(
+    `Package ${packageJson.name} is missing published entrypoints:\n${missingEntrypoints
+      .map((entrypoint) => `- ${entrypoint}`)
+      .join('\n')}`
+  )
+  process.exit(1)
+}
+
+console.log(`Verified ${entrypoints.size} entrypoints for ${packageJson.name}`)


### PR DESCRIPTION
## Summary

- build WebSocket JavaScript, declarations, and the Expo plugin during `prepack`
- force the TypeScript build so stale `.tsbuildinfo` cannot skip deleted `lib/` outputs
- verify every manifest entrypoint against the actual npm tarball in CI

The published `react-native-nitro-websockets@1.3.0` artifact contains no `lib/*` files while its default export still targets `./lib/index.js`. This keeps release artifacts self-contained and does not change runtime networking behavior.

Fixes #180

## Verification

- RED: clean package check reported missing `lib/index`, `lib/index.d.ts`, and `lib/index.js`
- GREEN: actual `npm pack` verified all 7 manifest entrypoints
- extracted the tarball into a blank consumer and confirmed `require.resolve()` targets `lib/index.js`
- `bun lint` — 0 errors; 2 existing no-shadow warnings
- `bun typecheck`
- `bun websockets typecheck`
- `bun test --maxWorkers=2 --coverage` — 10 passed, 2 existing todos
- `bun prepare`
- `git diff --check`

No dependency or lockfile changes.