### PR TITLE
fix(websockets): clear stale TypeScript build info

### DIFF
--- a/packages/react-native-nitro-websockets/package.json
+++ b/packages/react-native-nitro-websockets/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf android/build node_modules/**/android/build lib expo/plugins/dist",
+    "clean": "rm -rf android/build node_modules/**/android/build lib expo/plugins/dist tsconfig.tsbuildinfo",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
     "typescript": "tsc",


### PR DESCRIPTION
## Summary

- remove stale TypeScript composite build metadata in the existing WebSocket clean step
- let the existing `clean → specs → release` workflow regenerate `lib` instead of trusting deleted outputs
- supersede the prepack-based approach in #181 with the root-cause fix requested in maintainer feedback

Fixes #180.

## Root cause

`react-native-nitro-websockets` uses `composite: true`, so TypeScript writes `tsconfig.tsbuildinfo` beside its config. The package clean script removed `lib/` but left that cache. A subsequent `tsc --noEmit false` exited successfully without recreating `lib`, because the incremental state still considered the deleted outputs current.

This also explains why the unchanged release command produced different artifacts: npm 1.2.1 was packed while generated output was present, whereas 1.3.0 was packed after `lib` had been cleaned but its build-info cache survived. The package scripts and tsconfig are unchanged between the two published git heads (`43bd0ab` and `711085b`).

## Verification

- Reproduction before this change: with `lib/` absent and stale `tsconfig.tsbuildinfo` present, `tsc` exits 0, emits no files, and `npm pack --dry-run` contains 0 `lib/*` files.
- `bun websockets clean`
- `bun websockets specs`
- `bun websockets build:plugin`
- `bun websockets typecheck`
- `npm pack --dry-run --json --workspace packages/react-native-nitro-websockets`
  - contains all 6 generated `lib/*` files
  - contains `lib/index.js` and `lib/index.d.ts`
- `bun x prettier --check packages/react-native-nitro-websockets/package.json`
- `git diff --check`

An actual publish was not attempted; release-it correctly requires maintainer npm credentials.