### PR TITLE
fix: preserve fetch bodies, cancellation and native prefetch semantics

### DIFF
--- a/docs-website/docs/streaming.md
+++ b/docs-website/docs/streaming.md
@@ -71,3 +71,11 @@ Pass `{ stream: true }` in the fetch options to enable streaming mode. Without i
 4. Decode each `Uint8Array` chunk with `TextDecoder` for UTF-8 text
 
 Streaming is supported on both Android and iOS.
+
+## Body consumption and redirects
+
+`text()`, `json()`, `arrayBuffer()`, `bytes()` and `blob()` consume the stream. A consumed or locked body cannot be read or cloned again; clone before reading when two consumers need it. Empty input is not valid JSON.
+
+Streaming honors `redirect: 'follow' | 'manual' | 'error'`. Native manual mode returns the 3xx response without following it; browser manual mode retains the browser's opaque-response behavior. Aborting rejects the response promise or errors an already-resolved response body.
+
+Streaming does not consult the prefetch cache. iOS delivers data without URLSession backpressure, so slow consumers and slow clone branches can accumulate buffered data.

--- a/docs/fetch-compatibility.md
+++ b/docs/fetch-compatibility.md
@@ -1,0 +1,17 @@
+# Fetch compatibility corrections
+
+These corrections preserve the native transport API, but applications relying on the previous permissive behavior should check the following changes:
+
+- Request and Response body readers consume the actual body, including Blob and ReadableStream inputs. Reusing a consumed or locked body rejects instead of returning empty data. Clone before reading when two consumers need the body. Empty JSON rejects with `SyntaxError`; an empty body is not JSON `null`.
+- Constructing a Request from another Request transfers its body. `clone()` keeps both copies readable. GET and HEAD bodies are rejected, including when a method override would otherwise silently discard an existing body.
+- Public Response construction validates the status, status text, and bodyless statuses. `Response.json(undefined)` rejects. String bodies get the default `text/plain;charset=UTF-8` content type. Native FormData uploads remain supported, but serializing FormData through Nitro Request body readers or the Nitro Response constructor is unsupported and now rejects explicitly.
+- HTTP response bytes are preserved when they are not valid UTF-8. `text()` and `json()` use UTF-8 decoding, not the response charset parameter. Use `arrayBuffer()` and a decoder for a different encoding when needed. Non-empty conversions without an available UTF-8 codec reject rather than silently returning empty data; install the required global codec polyfill before converting bodies.
+- `data:` URLs preserve percent-encoded binary bytes, percent-decode base64 input, and exclude URL fragments from the body.
+- RequestInit overrides and inherited AbortSignals are honored. HTTP aborts reject even while the native request is joining a prefetch. The web/no-native adapters preserve Request options and let platform fetch consume standard Request inputs once. They still return non-2xx HTTP responses normally.
+- Streaming redirect `follow`, `manual`, and `error` modes are handled explicitly. Native manual mode exposes the 3xx response, unlike a browser's opaque manual redirect response. Terminal callbacks clean up abort listeners; late callbacks do not revive completed/cancelled streams.
+- On iOS, awaiting `prefetch()` now waits for completion and propagates failures, including when joining an existing prefetch. Automatic launch prefetching remains best-effort.
+- `prefetchCacheTtlMs` must be finite. Zero/negative values disable reuse of completed cached responses; they do not cancel or prevent joining an in-flight prefetch. Cache age uses a monotonic clock. The existing platform-specific cache consumption policy is unchanged.
+
+## Remaining boundaries
+
+This is not a claim of complete browser Fetch conformance. `formData()` readers remain unsupported. Native streaming is separate from the buffered/prefetch transport; iOS pushes data without URLSession backpressure, and slow consumers can accumulate queued data. Local file operations are not made natively cancellable by the HTTP abort changes. Cloning a stream can also buffer data for its slower reader.

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -42,6 +42,8 @@ Notes
 
 - Prefetch is best-effort; if native is unavailable, calls are ignored or fall back to JS fetch.
 - Responses served from prefetch add header `nitroPrefetched: true`.
+- When native is available, `await prefetch()` waits for completion and rejects on failure on both platforms. Automatic app-start replay still ignores individual request failures.
+- `prefetchCacheTtlMs` is a finite number of milliseconds (default 5000). Zero or negative values skip completed cached responses; an in-flight prefetch can still be joined.
 
 ## Why Prefetch Is Cool
 

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/FetchCache.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/FetchCache.kt
@@ -21,7 +21,7 @@ object FetchCache {
   }
 
   fun complete(key: String, value: NitroResponse) {
-    results[key] = CachedEntry(value, System.currentTimeMillis())
+    results[key] = CachedEntry(value, System.nanoTime() / 1_000_000)
     pending.remove(key)?.complete(value)
   }
 
@@ -36,8 +36,8 @@ object FetchCache {
 
   fun getResultIfFresh(key: String, maxAgeMs: Long): NitroResponse? {
     val entry = results.remove(key) ?: return null
-    val age = System.currentTimeMillis() - entry.timestampMs
-    return if (age <= maxAgeMs) entry.response else null
+    val age = System.nanoTime() / 1_000_000 - entry.timestampMs
+    return if (maxAgeMs > 0 && age <= maxAgeMs) entry.response else null
   }
 
   /**
@@ -46,8 +46,10 @@ object FetchCache {
    */
   fun hasFreshResult(key: String, maxAgeMs: Long): Boolean {
     val entry = results[key] ?: return false
-    val age = System.currentTimeMillis() - entry.timestampMs
-    return age <= maxAgeMs
+    val age = System.nanoTime() / 1_000_000 - entry.timestampMs
+    if (maxAgeMs > 0 && age <= maxAgeMs) return true
+    results.remove(key, entry)
+    return false
   }
 
   fun clear() {

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -14,8 +14,6 @@ import org.chromium.net.UrlResponseInfo
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
-import java.nio.charset.CharsetDecoder
 import java.nio.charset.CodingErrorAction
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -40,15 +38,6 @@ private val utf8StrictDecoder = ThreadLocal.withInitial {
     .onMalformedInput(CodingErrorAction.REPORT)
     .onUnmappableCharacter(CodingErrorAction.REPORT)
 }
-
-private fun strictDecoderFor(charset: Charset): CharsetDecoder =
-  if (charset == Charsets.UTF_8) {
-    utf8StrictDecoder.get()
-  } else {
-    charset.newDecoder()
-      .onMalformedInput(CodingErrorAction.REPORT)
-      .onUnmappableCharacter(CodingErrorAction.REPORT)
-  }
 
 // Wrap raw bytes into a Nitro ArrayBuffer for zero-base64 bridging to JS.
 private fun ByteArray.toArrayBuffer(): ArrayBuffer {
@@ -77,12 +66,16 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
     return null
   }
 
+  private fun cacheTtlMs(req: NitroRequest): Long =
+    req.prefetchCacheTtlMs?.let { if (it.isFinite()) it.toLong() else 0L } ?: 5_000L
+
   companion object {
     @JvmStatic
     fun fetch(
       req: NitroRequest,
       onSuccess: (NitroResponse) -> Unit,
-      onFail: (Throwable) -> Unit
+      onFail: (Throwable) -> Unit,
+      onStart: (UrlRequest) -> Unit = {}
     ): UrlRequest? {
       return try {
         // Local resources (file://, content://, scheme-less paths) aren't HTTP; read off disk -> 200.
@@ -92,7 +85,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
         }
         val engine = HybridNitroFetch.getEngine()
         val executor = HybridNitroFetch.ioExecutor
-        startCronet(engine, executor, req, onSuccess, onFail)
+        startCronet(engine, executor, req, onSuccess, onFail, onStart)
       } catch (t: Throwable) {
         onFail(t)
         null
@@ -104,7 +97,8 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       executor: Executor,
       req: NitroRequest,
       onSuccess: (NitroResponse) -> Unit,
-      onFail: (Throwable) -> Unit
+      onFail: (Throwable) -> Unit,
+      onStart: (UrlRequest) -> Unit
     ): UrlRequest {
       val url = req.url
       val shouldFollowRedirects = req.followRedirects ?: true
@@ -219,20 +213,10 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
               info.allHeadersAsList.map { NitroHeader(it.key, it.value) }.toTypedArray()
             val status = info.httpStatusCode
             val bytes = out.toByteArray()
-            val contentType = info.allHeaders["Content-Type"] ?: info.allHeaders["content-type"]
-            val charset = run {
-              val ct = contentType ?: ""
-              val m = Regex("charset=([A-Za-z0-9_\\-:.]+)", RegexOption.IGNORE_CASE).find(ct.toString())
-              try {
-                if (m != null) java.nio.charset.Charset.forName(m.groupValues[1]) else Charsets.UTF_8
-              } catch (_: Throwable) {
-                Charsets.UTF_8
-              }
-            }
-            // Strict-decode the body as text. If it fails the response is binary,
-            // so we bridge the raw bytes as an ArrayBuffer instead — no base64.
+            // Only UTF-8 round-trips losslessly through the string bridge.
+            // Preserve other encodings as bytes for the Fetch body readers.
             val bodyStr: String? = try {
-              strictDecoderFor(charset).decode(ByteBuffer.wrap(bytes)).toString()
+              utf8StrictDecoder.get().decode(ByteBuffer.wrap(bytes)).toString()
             } catch (_: Throwable) { null }
             val bodyBytesAb: ArrayBuffer? = if (bodyStr == null && bytes.isNotEmpty())
               bytes.toArrayBuffer()
@@ -320,6 +304,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
           encoded
         )
       }
+      onStart(request)
       request.start()
       return request
     }
@@ -333,7 +318,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       req.bodyBytesBase64?.takeIf { it.isNotEmpty() }?.let {
         return runCatching { android.util.Base64.decode(it, android.util.Base64.DEFAULT) }.getOrNull()
       }
-      return req.bodyString?.takeIf { it.isNotEmpty() }?.toByteArray(Charsets.UTF_8)
+      return req.bodyString?.toByteArray(Charsets.UTF_8)
     }
 
     private fun createUploadProvider(body: ByteArray): org.chromium.net.UploadDataProvider {
@@ -385,7 +370,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
     }
 
     private fun readFileBytes(uri: String): ByteArray {
-      if (uri.startsWith("http://") || uri.startsWith("https://")) {
+      if (isHttpURL(uri)) {
         val url = java.net.URL(uri)
         return url.openStream().use { it.readBytes() }
       }
@@ -404,7 +389,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       if (uri.startsWith("file://")) Uri.parse(uri).path ?: uri.removePrefix("file://") else uri
 
     private fun isHttpURL(url: String): Boolean =
-      url.startsWith("http://") || url.startsWith("https://")
+      url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
 
     private fun guessMime(uri: String): String {
       if (uri.startsWith("content://")) {
@@ -423,7 +408,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       val bytes = readFileBytes(req.url)
       val mime = guessMime(req.url)
       val bodyStr: String? = try {
-        strictDecoderFor(Charsets.UTF_8).decode(ByteBuffer.wrap(bytes)).toString()
+        utf8StrictDecoder.get().decode(ByteBuffer.wrap(bytes)).toString()
       } catch (_: Throwable) { null }
       val bodyBytesAb: ArrayBuffer? = if (bodyStr == null && bytes.isNotEmpty())
         bytes.toArrayBuffer()
@@ -470,7 +455,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
           throw e.cause ?: e
         }
       }
-      FetchCache.getResultIfFresh(key, req.prefetchCacheTtlMs?.toLong() ?: 5_000L)?.let { cached ->
+      FetchCache.getResultIfFresh(key, cacheTtlMs(req))?.let { cached ->
         return withPrefetchedHeader(cached)
       }
     }
@@ -513,13 +498,13 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
         return promise
       }
       // If a fresh prefetched result exists, return it immediately
-      FetchCache.getResultIfFresh(key, req.prefetchCacheTtlMs?.toLong() ?: 5_000L)?.let { cached ->
+      FetchCache.getResultIfFresh(key, cacheTtlMs(req))?.let { cached ->
         promise.resolve(withPrefetchedHeader(cached))
         return promise
       }
     }
     val requestId = req.requestId
-    val urlRequest = fetch(
+    fetch(
       req,
       onSuccess = { res ->
         if (requestId != null) activeRequests.remove(requestId)
@@ -528,13 +513,11 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       onFail = { err ->
         if (requestId != null) activeRequests.remove(requestId)
         promise.reject(err)
+      },
+      onStart = { request ->
+        if (requestId != null) activeRequests[requestId] = request
       }
     )
-    // Store after start() — if cancelRequest races and misses, the JS
-    // catch block checks signal.aborted and throws AbortError anyway.
-    if (requestId != null && urlRequest != null) {
-      activeRequests[requestId] = urlRequest
-    }
     return promise
   }
 
@@ -546,7 +529,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       return promise
     }
     // If already have a fresh result, resolve immediately (NON-DESTRUCTIVE CHECK)
-    if (FetchCache.hasFreshResult(key, req.prefetchCacheTtlMs?.toLong() ?: 5_000L)) {
+    if (FetchCache.hasFreshResult(key, cacheTtlMs(req))) {
       promise.resolve(Unit)
       return promise
     }

--- a/packages/react-native-nitro-fetch/ios/FetchCache.swift
+++ b/packages/react-native-nitro-fetch/ios/FetchCache.swift
@@ -3,7 +3,7 @@ import Foundation
 final class FetchCache {
   struct CachedEntry {
     let response: NitroResponse
-    let timestampMs: Int64
+    let timestampMs: Double
   }
 
   private static let lock = NSLock()
@@ -40,19 +40,19 @@ final class FetchCache {
     lock.lock()
     let callbacks = pending.removeValue(forKey: key) ?? []
     if case let .success(resp) = result {
-      results[key] = CachedEntry(response: resp, timestampMs: Int64(Date().timeIntervalSince1970 * 1000))
+      results[key] = CachedEntry(response: resp, timestampMs: ProcessInfo.processInfo.systemUptime * 1000)
     }
     lock.unlock()
     // Outside the lock: a callback may re-enter FetchCache.
     callbacks.forEach { $0(result) }
   }
 
-  static func getResultIfFresh(_ key: String, maxAgeMs: Int64) -> NitroResponse? {
+  static func getResultIfFresh(_ key: String, maxAgeMs: Double) -> NitroResponse? {
     lock.lock()
     defer { lock.unlock() }
     guard let entry = results[key] else { return nil }
-    let age = Int64(Date().timeIntervalSince1970 * 1000) - entry.timestampMs
-    if age <= maxAgeMs { return entry.response }
+    let age = ProcessInfo.processInfo.systemUptime * 1000 - entry.timestampMs
+    if maxAgeMs.isFinite && maxAgeMs > 0 && age <= maxAgeMs { return entry.response }
     results.removeValue(forKey: key)
     return nil
   }

--- a/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroCronet.swift
@@ -18,7 +18,7 @@ class HybridNitroCronet: HybridNitroCronetSpec {
   )
 
   func newUrlRequestBuilder(url: String) throws -> any HybridUrlRequestBuilderSpec {
-    return HybridUrlRequestBuilder(
+    return try HybridUrlRequestBuilder(
       url: url,
       session: HybridNitroCronet.session,
       executor: HybridNitroCronet.executorQueue

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -12,12 +12,6 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
   private var _lock = os_unfair_lock()
   private var activeTasks: [String: Task<Void, Never>] = [:]
 
-  private func storeTask(_ task: Task<Void, Never>, forKey key: String) {
-    os_unfair_lock_lock(&_lock)
-    activeTasks[key] = task
-    os_unfair_lock_unlock(&_lock)
-  }
-
   private func removeTask(forKey key: String) {
     os_unfair_lock_lock(&_lock)
     activeTasks.removeValue(forKey: key)
@@ -62,6 +56,8 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     let requestId = req.requestId
     let bodyData = HybridNitroFetchClient.uploadData(from: req)
 
+    // Completion and cancellation must not race ahead of registration.
+    if requestId != nil { os_unfair_lock_lock(&_lock) }
     let task = Task { [weak self] in
       defer {
         if let rid = requestId {
@@ -77,7 +73,8 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     }
 
     if let rid = requestId {
-      storeTask(task, forKey: rid)
+      activeTasks[rid] = task
+      os_unfair_lock_unlock(&_lock)
     }
     return promise
   }
@@ -137,7 +134,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     }
     if let key = findPrefetchKey(req) {
       // If a prefetched result is fresh, return immediately
-      if let cached = FetchCache.getResultIfFresh(key, maxAgeMs: Int64(req.prefetchCacheTtlMs ?? 5_000)) {
+      if let cached = FetchCache.getResultIfFresh(key, maxAgeMs: req.prefetchCacheTtlMs ?? 5_000) {
         var headers = cached.headers ?? []
         headers.append(NitroHeader(key: "nitroPrefetched", value: "true"))
         return NitroResponse(url: cached.url,
@@ -162,7 +159,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
           }
 
           if !attached {
-            continuation.resume(returning: FetchCache.getResultIfFresh(key, maxAgeMs: Int64(req.prefetchCacheTtlMs ?? 5_000)))
+            continuation.resume(returning: FetchCache.getResultIfFresh(key, maxAgeMs: req.prefetchCacheTtlMs ?? 5_000))
           }
         }
         if let res = joined {
@@ -181,7 +178,12 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
       }
     }
 
-    let (urlRequest, finalURL) = try await buildURLRequest(req, bodyData: bodyData)
+    return try await performRequest(req, bodyData: bodyData)
+  }
+
+  private static func performRequest(_ req: NitroRequest, bodyData: Data?) async throws -> NitroResponse {
+    if !isHttpURL(req.url) { return try makeLocalFileResponse(req) }
+    let urlRequest = try await buildURLRequest(req, bodyData: bodyData)
     let shouldFollowRedirects = req.followRedirects ?? true
     let delegate: URLSessionTaskDelegate? = shouldFollowRedirects ? nil : NoRedirectDelegate()
 
@@ -235,7 +237,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
       for h in headersPairs { headerDict[h.key] = h.value }
       NitroDevToolsReporter.reportResponseStart(
         devToolsId,
-        url: finalURL?.absoluteString ?? http.url?.absoluteString ?? req.url,
+        url: http.url?.absoluteString ?? req.url,
         statusCode: http.statusCode,
         headers: headerDict
       )
@@ -254,22 +256,20 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     }
     #endif
 
-    // Choose bodyString by default (matching Android’s first pass).
-    // For binary responses that can’t be decoded as text, bridge the raw bytes
-    // as an ArrayBuffer so arrayBuffer() / bytes() return them with no base64.
-    let charset = HybridNitroFetchClient.detectCharset(from: http) ?? String.Encoding.utf8
-    let bodyStr = String(data: data, encoding: charset) ?? String(data: data, encoding: .utf8)
+    // Only UTF-8 round-trips losslessly through the string bridge. Other
+    // encodings stay as bytes; Fetch body readers always decode as UTF-8.
+    let bodyStr = String(data: data, encoding: .utf8)
     var bodyBytesAb: ArrayBuffer? = nil
     if bodyStr == nil && !data.isEmpty {
       bodyBytesAb = try ArrayBuffer.copy(data: data)
     }
 
     let res = NitroResponse(
-      url: finalURL?.absoluteString ?? http.url?.absoluteString ?? req.url,
+      url: http.url?.absoluteString ?? req.url,
       status: Double(http.statusCode),
       statusText: HTTPURLResponse.localizedString(forStatusCode: http.statusCode),
       ok: (200...299).contains(http.statusCode),
-      redirected: (finalURL?.absoluteString ?? http.url?.absoluteString ?? req.url) != req.url,
+      redirected: (http.url?.absoluteString ?? req.url) != req.url,
       headers: headersPairs,
       bodyString: bodyStr,
       bodyBytes: bodyBytesAb
@@ -290,60 +290,37 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
       throw NSError(domain: "NitroFetch", code: -2, userInfo: [NSLocalizedDescriptionKey: "prefetch: missing 'prefetchKey' header"])
     }
 
-    if FetchCache.getResultIfFresh(key, maxAgeMs: Int64(req.prefetchCacheTtlMs ?? 5_000)) != nil {
-      return // already have a fresh result
-    }
-
-    // Mark pending and start the request. beginPending is atomic, so two racing
-    // prefetches for the same key cannot both start one.
-    guard FetchCache.beginPending(key) else {
-      return // already pending
-    }
-    Task.detached {
-      do {
-        let (urlRequest, finalURL) = try await buildURLRequest(req, bodyData: bodyData)
-        let (data, response) = try await session.data(for: urlRequest)
-        guard let http = response as? HTTPURLResponse else {
-          throw NSError(domain: "NitroFetch", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
-        }
-        let headersPairs: [NitroHeader] = http.allHeaderFields.compactMap { k, v in
-          guard let key = k as? String else { return nil }
-          return NitroHeader(key: key, value: String(describing: v))
-        }
-        let charset = HybridNitroFetchClient.detectCharset(from: http) ?? .utf8
-        let bodyStr = String(data: data, encoding: charset) ?? String(data: data, encoding: .utf8)
-        var bodyBytesAb: ArrayBuffer? = nil
-        if bodyStr == nil && !data.isEmpty {
-          bodyBytesAb = try ArrayBuffer.copy(data: data)
-        }
-        let res = NitroResponse(
-          url: finalURL?.absoluteString ?? http.url?.absoluteString ?? req.url,
-          status: Double(http.statusCode),
-          statusText: HTTPURLResponse.localizedString(forStatusCode: http.statusCode),
-          ok: (200...299).contains(http.statusCode),
-          redirected: (finalURL?.absoluteString ?? http.url?.absoluteString ?? req.url) != req.url,
-          headers: headersPairs,
-          bodyString: bodyStr,
-          bodyBytes: bodyBytesAb
-        )
-        FetchCache.complete(key, with: .success(res))
-      } catch {
-        FetchCache.complete(key, with: .failure(error))
+    while true {
+      if FetchCache.getResultIfFresh(key, maxAgeMs: req.prefetchCacheTtlMs ?? 5_000) != nil {
+        return
       }
+      if FetchCache.beginPending(key) { break }
+      let joined = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
+        let attached = FetchCache.joinPending(key) { result in
+          continuation.resume(with: result.map { _ in true })
+        }
+        if !attached { continuation.resume(returning: false) }
+      }
+      if joined { return }
+      // The previous request completed between beginPending and joinPending.
+      // Recheck the cache before trying to become the next owner.
+    }
+    do {
+      let response = try await performRequest(req, bodyData: bodyData)
+      FetchCache.complete(key, with: .success(response))
+    } catch {
+      FetchCache.complete(key, with: .failure(error))
+      throw error
     }
   }
 
 
-  private static func reqToHttpMethod(_ req: NitroRequest) -> String? {
-    return req.method?.stringValue
-  }
-
-  private static func buildURLRequest(_ req: NitroRequest, bodyData: Data? = nil) async throws -> (URLRequest, URL?) {
+  private static func buildURLRequest(_ req: NitroRequest, bodyData: Data? = nil) async throws -> URLRequest {
     guard let url = URL(string: req.url) else {
       throw NSError(domain: "NitroFetch", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid URL: \(req.url)"])
     }
     var r = URLRequest(url: url)
-    if let m = req.method?.rawValue { r.httpMethod = reqToHttpMethod(req) }
+    if let method = req.method { r.httpMethod = method.stringValue }
     if let headers = req.headers {
       // prefetchKey is an internal cache key, never sent on the server
       for h in headers where h.key.caseInsensitiveCompare("prefetchKey") != .orderedSame {
@@ -361,7 +338,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     }
     if let t = req.timeoutMs, t > 0 { r.timeoutInterval = TimeInterval(t) / 1000.0 }
     if req.credentials == .omit { r.httpShouldHandleCookies = false }
-    return (r, nil)
+    return r
   }
 
   private static func buildMultipartBody(_ parts: [NitroFormDataPart]) async throws -> (Data, String) {
@@ -394,7 +371,7 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
   }
 
   private static func readFileData(_ uri: String) async throws -> Data {
-    if uri.hasPrefix("http://") || uri.hasPrefix("https://") {
+    if isHttpURL(uri) {
       guard let url = URL(string: uri) else {
         throw NSError(domain: "NitroFetch", code: -4, userInfo: [NSLocalizedDescriptionKey: "Invalid URL: \(uri)"])
       }
@@ -405,7 +382,8 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
   }
 
   private static func isHttpURL(_ url: String) -> Bool {
-    return url.hasPrefix("http://") || url.hasPrefix("https://")
+    let prefix = url.prefix(8).lowercased()
+    return prefix.hasPrefix("http://") || prefix == "https://"
   }
 
   // Some files are % encoded we need to convert it to correct format
@@ -457,18 +435,6 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     )
   }
 
-  private static func detectCharset(from http: HTTPURLResponse) -> String.Encoding? {
-    if let ct = http.value(forHTTPHeaderField: "Content-Type")?.lowercased() {
-      if let range = ct.range(of: "charset=") {
-        let charset = String(ct[range.upperBound...]).trimmingCharacters(in: .whitespaces)
-        let mapped = CFStringConvertIANACharSetNameToEncoding(charset as CFString)
-        if mapped != kCFStringEncodingInvalidId {
-          return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(mapped))
-        }
-      }
-    }
-    return nil
-  }
 }
 
 /// Delegate that prevents URLSession from following HTTP redirects.

--- a/packages/react-native-nitro-fetch/ios/HybridUrlRequest.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridUrlRequest.swift
@@ -5,6 +5,8 @@ class HybridUrlRequest: HybridUrlRequestSpec {
   private weak var task: URLSessionDataTask?
   private weak var delegate: URLSessionDelegate?
   private var isDoneFlag = false
+  private let lock = NSLock()
+  private var pendingRedirect: (URLRequest, (URLRequest?) -> Void)?
 
   init(task: URLSessionDataTask, delegate: URLSessionDelegate) {
     self.task = task
@@ -17,8 +19,11 @@ class HybridUrlRequest: HybridUrlRequestSpec {
   }
 
   func followRedirect() throws {
-    // Redirects are handled automatically by URLSession
-    // This is a no-op on iOS but required for API compatibility
+    lock.lock()
+    let pending = pendingRedirect
+    pendingRedirect = nil
+    lock.unlock()
+    if let (request, completion) = pending { completion(request) }
   }
 
   func read() throws {
@@ -27,15 +32,33 @@ class HybridUrlRequest: HybridUrlRequestSpec {
   }
 
   func cancel() throws {
+    markDone()
     task?.cancel()
-    isDoneFlag = true
   }
 
   func isDone() throws -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
     return isDoneFlag
   }
 
   func markDone() {
+    lock.lock()
     isDoneFlag = true
+    let pending = pendingRedirect
+    pendingRedirect = nil
+    lock.unlock()
+    pending?.1(nil)
+  }
+
+  func waitForRedirect(_ request: URLRequest, completion: @escaping (URLRequest?) -> Void) {
+    lock.lock()
+    if isDoneFlag {
+      lock.unlock()
+      completion(nil)
+    } else {
+      pendingRedirect = (request, completion)
+      lock.unlock()
+    }
   }
 }

--- a/packages/react-native-nitro-fetch/ios/HybridUrlRequestBuilder.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridUrlRequestBuilder.swift
@@ -28,13 +28,13 @@ class HybridUrlRequestBuilder: HybridUrlRequestBuilderSpec {
     url: String,
     session: URLSession,
     executor: DispatchQueue
-  ) {
+  ) throws {
     self.url = url
     self.session = session
     self.executor = executor
 
     guard let urlObj = URL(string: url) else {
-      fatalError("Invalid URL: \(url)")
+      throw URLError(.badURL)
     }
     self.urlRequest = URLRequest(url: urlObj)
   }
@@ -172,15 +172,18 @@ private class URLSessionDelegateAdapter: NSObject, URLSessionDataDelegate, URLSe
     newRequest request: URLRequest,
     completionHandler: @escaping (URLRequest?) -> Void
   ) {
-    executor.sync { [weak self] in
-      guard let self = self else { return }
-      if let callback = self.onRedirectReceived {
+    if let callback = onRedirectReceived, let hybridRequest = hybridRequest {
+      // Nitro callbacks reach JS asynchronously. Hold the native completion
+      // until JS explicitly follows or cancels, matching Android/Cronet.
+      hybridRequest.waitForRedirect(request, completion: completionHandler)
+      executor.sync {
         let info = response.toNitro()
         let newUrl = request.url?.absoluteString ?? ""
         callback(info, newUrl)
       }
+    } else {
+      completionHandler(request)
     }
-    completionHandler(request)
   }
 
   func urlSession(

--- a/packages/react-native-nitro-fetch/src/Body.ts
+++ b/packages/react-native-nitro-fetch/src/Body.ts
@@ -1,0 +1,193 @@
+import { stringToUTF8, utf8ToString } from './utf8';
+import { bytesToBlob } from './blob';
+
+type ByteStream = ReadableStream<Uint8Array<ArrayBuffer>>;
+
+interface BodySource {
+  bytes?: ArrayBuffer;
+  text?: string;
+  stream?: ByteStream;
+  blob?: Blob;
+}
+
+export function readBlob(blob: Blob): Promise<ArrayBuffer> {
+  if (typeof blob.arrayBuffer === 'function') return blob.arrayBuffer();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.onabort = () => reject(new TypeError('Blob reading was aborted.'));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/** Shared consumption state for buffered, Blob and streaming response bodies. */
+export class Body {
+  private exposed: ByteStream | undefined;
+  private state = { used: false };
+
+  constructor(private source: BodySource = {}) {}
+
+  private get present(): boolean {
+    return (
+      this.source.bytes != null ||
+      this.source.text != null ||
+      this.source.stream != null ||
+      this.source.blob != null
+    );
+  }
+
+  get used(): boolean {
+    return this.state.used;
+  }
+
+  assertUsable(): void {
+    if (this.used || this.exposed?.locked || this.source.stream?.locked) {
+      throw new TypeError('Body has already been consumed or is locked.');
+    }
+  }
+
+  get stream(): ByteStream | null {
+    if (!this.present) return null;
+    if (this.exposed) return this.exposed;
+    // Capture state rather than `this`: tee() replaces the original body's
+    // state, and reading its old stream must not disturb the new branch.
+    const source = this.source;
+    const state = this.state;
+    const alreadyUsed = state.used;
+    let reader:
+      | ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>
+      | undefined;
+    this.exposed = new ReadableStream<Uint8Array<ArrayBuffer>>(
+      {
+        async pull(controller) {
+          state.used = true;
+          if (alreadyUsed) {
+            controller.close();
+            return;
+          }
+          if (source.stream) {
+            reader ??= source.stream.getReader();
+            try {
+              const { done, value } = await reader.read();
+              if (done) {
+                reader.releaseLock();
+                controller.close();
+              } else {
+                // Default stream tee() shares chunks; each exposed branch
+                // needs independent bytes, as does a buffered body reader.
+                controller.enqueue(value.slice());
+              }
+            } catch (error) {
+              reader.releaseLock();
+              throw error;
+            }
+          } else {
+            const bytes = source.blob
+              ? new Uint8Array(await readBlob(source.blob))
+              : source.bytes
+                ? new Uint8Array(source.bytes.slice(0))
+                : stringToUTF8(source.text ?? '');
+            controller.enqueue(bytes as Uint8Array<ArrayBuffer>);
+            controller.close();
+          }
+        },
+        async cancel(reason) {
+          state.used = true;
+          if (reader) {
+            try {
+              await reader.cancel(reason);
+            } finally {
+              reader.releaseLock();
+            }
+          } else {
+            await source.stream?.cancel(reason);
+          }
+        },
+      },
+      // Do not mark a body used merely because its getter was accessed.
+      { highWaterMark: 0 }
+    );
+    return this.exposed;
+  }
+
+  async text(): Promise<string> {
+    this.assertUsable();
+    if (!this.exposed && !this.source.stream && !this.source.blob) {
+      this.state.used = this.present;
+      if (this.source.text != null) {
+        // Fetch text decoding strips a leading UTF-8 BOM; native string fast
+        // paths must match the byte decoder without re-encoding the body.
+        const text = this.source.text;
+        return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+      }
+      return this.source.bytes
+        ? utf8ToString(new Uint8Array(this.source.bytes))
+        : '';
+    }
+    return utf8ToString(new Uint8Array(await this.arrayBuffer()));
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    this.assertUsable();
+    if (!this.exposed && !this.source.stream) {
+      this.state.used = this.present;
+      if (this.source.blob) return readBlob(this.source.blob);
+      if (this.source.bytes) return this.source.bytes.slice(0);
+      const bytes = stringToUTF8(this.source.text ?? '');
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      ) as ArrayBuffer;
+    }
+    const stream = this.stream!;
+    this.state.used = true;
+    const reader = stream.getReader();
+    const chunks: Uint8Array<ArrayBuffer>[] = [];
+    let size = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        size += value.byteLength;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const bytes = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes.buffer;
+  }
+
+  async blob(type: string): Promise<Blob> {
+    this.assertUsable();
+    if (!this.exposed && !this.source.stream && !this.source.bytes) {
+      this.state.used = this.present;
+      if (this.source.blob) {
+        return this.source.blob.slice(0, this.source.blob.size, type);
+      }
+      // Keep text-backed blobs on the JS path; no UTF-8/base64 native roundtrip.
+      return new Blob([this.source.text ?? ''], { type });
+    }
+    return bytesToBlob(await this.arrayBuffer(), type);
+  }
+
+  clone(): Body {
+    this.assertUsable();
+    if (!this.exposed && !this.source.stream) {
+      // Buffered sources are private; arrayBuffer() and stream chunks copy
+      // before exposing mutable bytes. Blob and string sources are immutable.
+      return new Body(this.source);
+    }
+    const [original, clone] = this.stream!.tee();
+    this.source = { stream: original };
+    this.exposed = undefined;
+    this.state = { used: false };
+    return new Body({ stream: clone });
+  }
+}

--- a/packages/react-native-nitro-fetch/src/Request.ts
+++ b/packages/react-native-nitro-fetch/src/Request.ts
@@ -1,6 +1,5 @@
 import { NitroHeaders } from './Headers';
-import { stringToUTF8, utf8ToString } from './utf8';
-import { bytesToBlob } from './blob';
+import { Body } from './Body';
 
 export type RequestRedirect = 'follow' | 'error' | 'manual';
 export type RequestCache =
@@ -42,6 +41,7 @@ export class NitroRequest {
   readonly destination: RequestDestination;
 
   private _body: BodyInit | null;
+  private _bodyState: Body;
   private _bodyUsed: boolean = false;
 
   constructor(
@@ -49,6 +49,7 @@ export class NitroRequest {
     init?: NitroRequestInit
   ) {
     if (input instanceof NitroRequest) {
+      if (init?.body == null) input._throwIfBodyUsed();
       // Clone from another NitroRequest
       this.url = input.url;
       this.method = (init?.method ?? input.method).toUpperCase();
@@ -60,7 +61,10 @@ export class NitroRequest {
           : input.headers
       );
       this.redirect = init?.redirect ?? input.redirect;
-      this.signal = init?.signal ?? input.signal;
+      this.signal =
+        init?.signal === null
+          ? new AbortController().signal
+          : (init?.signal ?? input.signal);
       this.cache = init?.cache ?? input.cache;
       this.credentials = init?.credentials ?? input.credentials;
       this.mode = init?.mode ?? input.mode;
@@ -68,7 +72,7 @@ export class NitroRequest {
       this.referrerPolicy = init?.referrerPolicy ?? input.referrerPolicy;
       this.integrity = init?.integrity ?? input.integrity;
       this.keepalive = init?.keepalive ?? input.keepalive;
-      this._body = init?.body !== undefined ? (init.body ?? null) : input._body;
+      this._body = init?.body ?? input._body;
     } else if (
       typeof input === 'object' &&
       input !== null &&
@@ -89,7 +93,10 @@ export class NitroRequest {
       );
       this.redirect =
         init?.redirect ?? (input.redirect as RequestRedirect) ?? 'follow';
-      this.signal = init?.signal ?? input.signal;
+      this.signal =
+        init?.signal === null
+          ? new AbortController().signal
+          : (init?.signal ?? input.signal);
       this.cache = init?.cache ?? (input.cache as RequestCache) ?? 'default';
       this.credentials =
         init?.credentials ?? input.credentials ?? 'same-origin';
@@ -99,7 +106,19 @@ export class NitroRequest {
         init?.referrerPolicy ?? (input.referrerPolicy as ReferrerPolicy) ?? '';
       this.integrity = init?.integrity ?? input.integrity ?? '';
       this.keepalive = init?.keepalive ?? input.keepalive ?? false;
-      this._body = init?.body ?? null;
+      if (init?.body == null && (input.bodyUsed || input.body?.locked)) {
+        throw new TypeError(
+          'Request body has already been consumed or is locked.'
+        );
+      }
+      if (init?.body != null) {
+        this._body = init.body;
+      } else {
+        this._body =
+          input.body ??
+          (input as unknown as { _bodyInit?: BodyInit })._bodyInit ??
+          null;
+      }
     } else {
       this.url = String(input);
       this.method = (init?.method ?? 'GET').toUpperCase();
@@ -123,101 +142,130 @@ export class NitroRequest {
     }
 
     this.destination = '';
+    if (
+      (this.method === 'GET' || this.method === 'HEAD') &&
+      this._body != null
+    ) {
+      throw new TypeError('GET and HEAD requests cannot have a body.');
+    }
+    // Transfer only after validation, so a rejected construction leaves the
+    // input usable. RN's Request stores opaque FormData in _bodyInit.
+    if (input instanceof Request && init?.body == null) {
+      const owned = new Request(input);
+      this._body =
+        owned.body ??
+        (owned as unknown as { _bodyInit?: BodyInit })._bodyInit ??
+        null;
+    }
+    this._bodyState = new Body();
+    if (
+      typeof URLSearchParams !== 'undefined' &&
+      this._body instanceof URLSearchParams
+    ) {
+      this._body = this._body.toString();
+      if (!this.headers.has('content-type'))
+        this.headers.set(
+          'content-type',
+          'application/x-www-form-urlencoded;charset=UTF-8'
+        );
+    }
+    if (typeof this._body === 'string') {
+      this._bodyState = new Body({ text: this._body });
+      if (!this.headers.has('content-type'))
+        this.headers.set('content-type', 'text/plain;charset=UTF-8');
+    } else if (
+      this._body instanceof ArrayBuffer ||
+      ArrayBuffer.isView(this._body)
+    ) {
+      const value = this._body;
+      this._body =
+        value instanceof ArrayBuffer
+          ? value.slice(0)
+          : (value.buffer as ArrayBuffer).slice(
+              value.byteOffset,
+              value.byteOffset + value.byteLength
+            );
+      this._bodyState = new Body({ bytes: this._body });
+    } else if (typeof Blob !== 'undefined' && this._body instanceof Blob) {
+      this._bodyState = new Body({ blob: this._body });
+      if (this._body.type && !this.headers.has('content-type'))
+        this.headers.set('content-type', this._body.type);
+    } else if (
+      typeof ReadableStream !== 'undefined' &&
+      this._body instanceof ReadableStream
+    ) {
+      this._bodyState = new Body({ stream: this._body });
+    }
+    if (
+      input instanceof NitroRequest &&
+      init?.body == null &&
+      this._body != null
+    ) {
+      input._bodyUsed = true;
+    }
   }
 
   get bodyUsed(): boolean {
-    return this._bodyUsed;
+    return this._bodyUsed || this._bodyState.used;
   }
 
   get body(): ReadableStream<Uint8Array<ArrayBuffer>> | null {
-    if (this._body == null) return null;
-    const bodyBytes = this._getBodyBytes();
-    if (!bodyBytes) return null;
-    return new ReadableStream<Uint8Array<ArrayBuffer>>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(bodyBytes));
-        controller.close();
-      },
-    });
+    return this._bodyState.stream;
   }
 
   private _throwIfBodyUsed(): void {
-    if (this._bodyUsed) {
+    if (this.bodyUsed) {
       throw new TypeError('Body has already been consumed.');
     }
-  }
-
-  private _getBodyBytes(): ArrayBuffer | undefined {
-    if (this._body == null) return undefined;
-    if (typeof this._body === 'string') {
-      const encoded = stringToUTF8(this._body);
-      return (encoded.buffer as ArrayBuffer).slice(
-        encoded.byteOffset,
-        encoded.byteOffset + encoded.byteLength
-      );
-    }
-    if (this._body instanceof ArrayBuffer) return this._body;
-    if (ArrayBuffer.isView(this._body)) {
-      const view = this._body;
-      return (view.buffer as ArrayBuffer).slice(
-        view.byteOffset,
-        view.byteOffset + view.byteLength
-      );
-    }
-    return undefined;
-  }
-
-  private _getBodyString(): string {
-    if (this._body == null) return '';
-    if (typeof this._body === 'string') return this._body;
-    const bytes = this._getBodyBytes();
-    if (bytes) return utf8ToString(new Uint8Array(bytes));
-    return '';
+    this._bodyState.assertUsable();
   }
 
   async text(): Promise<string> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    return this._getBodyString();
+    this._consumeBody();
+    return this._bodyState.text();
   }
 
   async json(): Promise<any> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    const t = this._getBodyString();
-    return JSON.parse(t || '{}');
+    return JSON.parse(await this.text());
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    return this._getBodyBytes() ?? new ArrayBuffer(0);
+    this._consumeBody();
+    return this._bodyState.arrayBuffer();
   }
 
   async blob(): Promise<Blob> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
+    this._consumeBody();
     const contentType = this.headers.get('content-type') ?? '';
-    if (this._body == null) return new Blob([], { type: contentType });
-    if (typeof this._body === 'string') {
-      return new Blob([this._body], { type: contentType });
-    }
-    // new Blob([arrayBuffer]) throws in RN — use the native blob registry.
-    return bytesToBlob(this._getBodyBytes() ?? new ArrayBuffer(0), contentType);
+    return this._bodyState.blob(contentType);
   }
 
   async bytes(): Promise<Uint8Array<ArrayBuffer>> {
+    return new Uint8Array(await this.arrayBuffer());
+  }
+
+  private _consumeBody(): void {
     this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    const buffer = this._getBodyBytes() ?? new ArrayBuffer(0);
-    return new Uint8Array(buffer);
+    if (typeof FormData !== 'undefined' && this._body instanceof FormData) {
+      throw new TypeError(
+        'Reading FormData bodies is not supported in NitroRequest.'
+      );
+    }
+    this._bodyUsed = this._body != null;
   }
 
   clone(): NitroRequest {
-    if (this._bodyUsed) {
-      throw new TypeError('Cannot clone a Request whose body has been used.');
+    this._throwIfBodyUsed();
+    const clone = new NitroRequest(this, { body: this._body });
+    if (
+      typeof ReadableStream !== 'undefined' &&
+      this._body instanceof ReadableStream
+    ) {
+      clone._bodyState = this._bodyState.clone();
+      this._body = this._bodyState.stream;
+      clone._body = clone._bodyState.stream;
     }
-    return new NitroRequest(this);
+    return clone;
   }
 
   async formData(): Promise<never> {
@@ -228,4 +276,17 @@ export class NitroRequest {
 // Raw BodyInit for buildNitroRequest; the spec `body` getter hands back a stream.
 export function rawBodyOf(req: NitroRequest): BodyInit | null {
   return (req as unknown as { _body: BodyInit | null })._body;
+}
+
+export function consumeRawBodyOf(req: NitroRequest): BodyInit | null {
+  if (req.bodyUsed)
+    throw new TypeError('Request body has already been consumed.');
+  const internal = req as unknown as {
+    _body: BodyInit | null;
+    _bodyUsed: boolean;
+    _bodyState: Body;
+  };
+  internal._bodyState.assertUsable();
+  if (internal._body != null) internal._bodyUsed = true;
+  return internal._body;
 }

--- a/packages/react-native-nitro-fetch/src/Response.ts
+++ b/packages/react-native-nitro-fetch/src/Response.ts
@@ -1,6 +1,5 @@
 import { NitroHeaders } from './Headers';
-import { stringToUTF8, utf8ToString } from './utf8';
-import { bytesToBlob } from './blob';
+import { Body } from './Body';
 import type { NitroHeader } from './NitroFetch.nitro';
 
 export type ResponseType =
@@ -43,10 +42,7 @@ export class NitroResponse {
   readonly headers: NitroHeaders;
   readonly type: ResponseType;
 
-  private _bodyBytes: ArrayBuffer | undefined;
-  private _bodyString: string | undefined;
-  private _bodyStream: ReadableStream<Uint8Array<ArrayBuffer>> | undefined;
-  private _bodyUsed: boolean = false;
+  private _body: Body;
 
   constructor(body?: BodyInit | null, init?: ResponseInit);
   constructor(init: NitroResponseInit);
@@ -64,48 +60,66 @@ export class NitroResponse {
       this.redirected = nitroInit.redirected;
       this.type = nitroInit.type ?? 'basic';
 
-      if (nitroInit.headers instanceof NitroHeaders) {
-        this.headers = nitroInit.headers;
-      } else {
-        this.headers = new NitroHeaders(nitroInit.headers);
-      }
-
-      this._bodyBytes = nitroInit.bodyBytes;
-      this._bodyString = nitroInit.bodyString;
-      this._bodyStream = nitroInit.body;
+      this.headers = new NitroHeaders(nitroInit.headers);
+      this._body = new Body({
+        bytes: nitroInit.bodyBytes,
+        text: nitroInit.bodyString,
+        stream: nitroInit.body,
+      });
     } else {
       // Public constructor: new Response(body?, init?)
       const body = bodyOrInit as BodyInit | null | undefined;
       this.status = init?.status ?? 200;
       this.statusText = init?.statusText ?? '';
+      if (
+        !Number.isInteger(this.status) ||
+        this.status < 200 ||
+        this.status > 599
+      ) {
+        throw new RangeError(
+          'Response status must be an integer between 200 and 599.'
+        );
+      }
+      if (/[^\t\x20-\x7e\x80-\xff]/.test(this.statusText)) {
+        throw new TypeError('Invalid response status text.');
+      }
+      if (body != null && [204, 205, 304].includes(this.status)) {
+        throw new TypeError('This response status cannot have a body.');
+      }
       this.ok = this.status >= 200 && this.status < 300;
       this.url = '';
       this.redirected = false;
       this.type = 'default';
       this.headers = new NitroHeaders(init?.headers as any);
+      this._body = new Body();
 
       if (body == null) {
         // no body
       } else if (typeof body === 'string') {
-        this._bodyString = body;
+        this._body = new Body({ text: body });
+        if (!this.headers.has('content-type')) {
+          this.headers.set('content-type', 'text/plain;charset=UTF-8');
+        }
       } else if (body instanceof ArrayBuffer) {
-        this._bodyBytes = body;
+        this._body = new Body({ bytes: body.slice(0) });
       } else if (ArrayBuffer.isView(body)) {
         const view = body as ArrayBufferView;
-        this._bodyBytes = (view.buffer as ArrayBuffer).slice(
-          view.byteOffset,
-          view.byteOffset + view.byteLength
-        );
+        this._body = new Body({
+          bytes: (view.buffer as ArrayBuffer).slice(
+            view.byteOffset,
+            view.byteOffset + view.byteLength
+          ),
+        });
       } else if (
         typeof ReadableStream !== 'undefined' &&
         body instanceof ReadableStream
       ) {
-        this._bodyStream = body;
+        this._body = new Body({ stream: body });
       } else if (
         typeof URLSearchParams !== 'undefined' &&
         body instanceof URLSearchParams
       ) {
-        this._bodyString = body.toString();
+        this._body = new Body({ text: body.toString() });
         if (!this.headers.has('content-type')) {
           this.headers.set(
             'content-type',
@@ -113,178 +127,58 @@ export class NitroResponse {
           );
         }
       } else if (typeof Blob !== 'undefined' && body instanceof Blob) {
-        // Store as string — RN Blobs are string-backed
-        this._bodyString = '';
-        this._bodyStream = body.stream?.() as
-          | ReadableStream<Uint8Array<ArrayBuffer>>
-          | undefined;
+        this._body = new Body({ blob: body });
+        if (body.type && !this.headers.has('content-type')) {
+          this.headers.set('content-type', body.type);
+        }
+      } else {
+        throw new TypeError('Unsupported NitroResponse body type.');
       }
     }
   }
 
   get bodyUsed(): boolean {
-    return this._bodyUsed;
+    return this._body.used;
   }
 
   get body(): ReadableStream<Uint8Array<ArrayBuffer>> | null {
-    if (this._bodyStream) return this._bodyStream;
-    const bytes = this._getBodyBytes();
-    if (!bytes) return null;
-    return new ReadableStream<Uint8Array<ArrayBuffer>>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(bytes));
-        controller.close();
-      },
-    });
-  }
-
-  private _throwIfBodyUsed(): void {
-    if (this._bodyUsed) {
-      throw new TypeError('Body has already been consumed.');
-    }
-  }
-
-  private _getBodyBytes(): ArrayBuffer | undefined {
-    // TODO: copy buffer to avoid clone being modifying res
-    if (this._bodyBytes != null) return this._bodyBytes;
-    if (this._bodyString != null) {
-      const encoded = stringToUTF8(this._bodyString);
-      return (encoded.buffer as ArrayBuffer).slice(
-        encoded.byteOffset,
-        encoded.byteOffset + encoded.byteLength
-      );
-    }
-    return undefined;
-  }
-
-  private _getBodyString(): string {
-    if (this._bodyString != null) return this._bodyString;
-    if (this._bodyBytes) {
-      return utf8ToString(new Uint8Array(this._bodyBytes));
-    }
-    return '';
+    return this._body.stream;
   }
 
   async text(): Promise<string> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    if (this._bodyStream && !this._bodyBytes && this._bodyString == null) {
-      const reader = this._bodyStream.getReader();
-      const chunks: Uint8Array[] = [];
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) chunks.push(value);
-      }
-      // Concatenate chunks
-      let totalLen = 0;
-      for (const c of chunks) totalLen += c.byteLength;
-      const merged = new Uint8Array(totalLen);
-      let offset = 0;
-      for (const c of chunks) {
-        merged.set(c, offset);
-        offset += c.byteLength;
-      }
-      return utf8ToString(merged);
-    }
-
-    return this._getBodyString();
+    return this._body.text();
   }
 
   async json(): Promise<any> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    const t = this._getBodyString();
-    return JSON.parse(t || '{}');
+    return JSON.parse(await this.text());
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    if (this._bodyStream && !this._bodyBytes && this._bodyString == null) {
-      const reader = this._bodyStream.getReader();
-      const chunks: Uint8Array[] = [];
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) chunks.push(value);
-      }
-      let totalLen = 0;
-      for (const c of chunks) totalLen += c.byteLength;
-      const merged = new Uint8Array(totalLen);
-      let offset = 0;
-      for (const c of chunks) {
-        merged.set(c, offset);
-        offset += c.byteLength;
-      }
-      return merged.buffer.slice(
-        merged.byteOffset,
-        merged.byteOffset + merged.byteLength
-      );
-    }
-
-    return this._getBodyBytes() ?? new ArrayBuffer(0);
-  }
-
-  // Same merge as arrayBuffer(); used only by blob().
-  private async _drainStream(): Promise<ArrayBuffer> {
-    const reader = this._bodyStream!.getReader();
-    const chunks: Uint8Array[] = [];
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) chunks.push(value);
-    }
-    let totalLen = 0;
-    for (const c of chunks) totalLen += c.byteLength;
-    const merged = new Uint8Array(totalLen);
-    let offset = 0;
-    for (const c of chunks) {
-      merged.set(c, offset);
-      offset += c.byteLength;
-    }
-    return merged.buffer.slice(
-      merged.byteOffset,
-      merged.byteOffset + merged.byteLength
-    );
+    return this._body.arrayBuffer();
   }
 
   async blob(): Promise<Blob> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
     const contentType = this.headers.get('content-type') ?? '';
-    if (this._bodyStream && !this._bodyBytes && this._bodyString == null) {
-      return bytesToBlob(await this._drainStream(), contentType);
-    }
-    // Prefer raw bytes: _bodyString is empty/lossy for non-UTF-8 bodies.
-    if (this._bodyBytes != null) {
-      return bytesToBlob(this._bodyBytes, contentType);
-    }
-    return new Blob([this._getBodyString()], { type: contentType });
+    return this._body.blob(contentType);
   }
 
   async bytes(): Promise<Uint8Array<ArrayBuffer>> {
-    this._throwIfBodyUsed();
-    this._bodyUsed = true;
-    const buffer = this._getBodyBytes() ?? new ArrayBuffer(0);
-    return new Uint8Array(buffer);
+    return new Uint8Array(await this.arrayBuffer());
   }
 
   clone(): NitroResponse {
-    if (this._bodyUsed) {
-      throw new TypeError('Cannot clone a Response whose body has been used.');
-    }
-    return new NitroResponse({
+    const body = this._body.clone();
+    const cloned = new NitroResponse({
       url: this.url,
       status: this.status,
       statusText: this.statusText,
       ok: this.ok,
       redirected: this.redirected,
       headers: this.headers,
-      bodyBytes: this._bodyBytes,
-      bodyString: this._bodyString,
       type: this.type,
     });
+    cloned._body = body;
+    return cloned;
   }
 
   async formData(): Promise<never> {
@@ -305,27 +199,18 @@ export class NitroResponse {
     });
   }
 
-  static json(
-    data: unknown,
-    init?: {
-      status?: number;
-      statusText?: string;
-      headers?: Record<string, string> | [string, string][];
-    }
-  ): NitroResponse {
+  static json(data: unknown, init?: ResponseInit): NitroResponse {
     const body = JSON.stringify(data);
+    if (body === undefined) {
+      throw new TypeError('The value cannot be serialized as JSON.');
+    }
     const headers = new NitroHeaders(init?.headers as any);
     if (!headers.has('content-type')) {
       headers.set('content-type', 'application/json');
     }
-    return new NitroResponse({
-      url: '',
-      status: init?.status ?? 200,
-      statusText: init?.statusText ?? '',
-      ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
-      redirected: false,
-      headers,
-      bodyString: body,
+    return new NitroResponse(body, {
+      ...init,
+      headers: headers as unknown as HeadersInit,
     });
   }
 
@@ -333,7 +218,9 @@ export class NitroResponse {
     const validStatuses = [301, 302, 303, 307, 308];
     if (!validStatuses.includes(status)) {
       throw new RangeError(
-        `Invalid redirect status: ${status}. Must be one of ${validStatuses.join(', ')}`
+        `Invalid redirect status: ${status}. Must be one of ${validStatuses.join(
+          ', '
+        )}`
       );
     }
     const headers = new NitroHeaders();

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -14,15 +14,41 @@ import {
 import { NativeStorage as NativeStorageSingleton } from './NitroInstances';
 import { NitroHeaders } from './Headers';
 import { NitroResponse } from './Response';
-import { NitroRequest as NitroRequestClass, rawBodyOf } from './Request';
+import {
+  NitroRequest as NitroRequestClass,
+  consumeRawBodyOf,
+  rawBodyOf,
+} from './Request';
 import type { RequestRedirect, RequestCache } from './Request';
+import type { UrlResponseInfo } from './NitroCronet.nitro';
 import { NetworkInspector } from './NetworkInspector';
 import { base64FromBytes } from './blob';
+import { readBlob } from './Body';
+import { platformFetch } from './platformFetch';
 
 const TEXT_CONTENT_TYPE = 'text/plain;charset=UTF-8';
 const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded;charset=UTF-8';
 // Browsers send no Content-Type for byte bodies, but Cronet rejects uploads without one.
 const BYTES_CONTENT_TYPE = 'application/octet-stream';
+
+function validatePrefetchTtl(value: number | undefined): number | undefined {
+  'worklet';
+  if (value !== undefined && !Number.isFinite(value)) {
+    throw new RangeError('prefetchCacheTtlMs must be a finite number.');
+  }
+  return value;
+}
+
+function validateRequestBody(method: string | undefined, body: unknown): void {
+  'worklet';
+  const normalizedMethod = method?.toUpperCase() ?? 'GET';
+  if (
+    (normalizedMethod === 'GET' || normalizedMethod === 'HEAD') &&
+    body != null
+  ) {
+    throw new TypeError('GET and HEAD requests cannot have a body.');
+  }
+}
 
 // A view spanning its whole buffer needs no copy.
 function viewToBuffer(view: ArrayBufferView): ArrayBuffer {
@@ -237,13 +263,16 @@ function buildNitroRequest(
   } else {
     // Standard Request object
     url = input.url;
-    method = input.method;
-    headersInit = input.headers as any;
+    method = init?.method ?? input.method;
+    headersInit = init?.headers ?? (input.headers as any);
     body = init?.body ?? null;
+    if (!init?.redirect) redirectOption = input.redirect ?? 'follow';
+    if (!init?.cache) cacheOption = input.cache;
     if (!init?.credentials) credentialsOption = (input as Request).credentials;
   }
 
   const headers = headersToPairs(headersInit) ?? [];
+  validateRequestBody(method, body);
   const normalized = normalizeBody(body);
   applyDefaultContentType(headers, normalized?.contentType);
 
@@ -252,10 +281,7 @@ function buildNitroRequest(
   // Determine followRedirects based on redirect option
   const followRedirects = redirectOption === 'follow';
 
-  const prefetchCacheTtlMs =
-    typeof init?.prefetchCacheTtlMs === 'number'
-      ? init.prefetchCacheTtlMs
-      : undefined;
+  const prefetchCacheTtlMs = validatePrefetchTtl(init?.prefetchCacheTtlMs);
 
   return {
     url,
@@ -386,21 +412,21 @@ export function buildNitroRequestPure(
     // Request object
     const req = input as Request;
     url = req.url;
-    method = req.method;
-    headersInit = req.headers;
+    method = init?.method ?? req.method;
+    headersInit = init?.headers ?? req.headers;
     // Clone body if needed – Request objects in RN typically allow direct access
     body = init?.body ?? null;
   }
 
   const headers = headersToPairsPure(headersInit) ?? [];
+  validateRequestBody(method, body);
   const normalized = normalizeBodyPure(body);
   applyDefaultContentType(headers, normalized?.contentType);
-  applyCacheHeaders(headers, init?.cache as RequestCache | undefined);
+  const inputRequest =
+    typeof input === 'string' || isUrlObject ? undefined : (input as Request);
+  applyCacheHeaders(headers, init?.cache ?? inputRequest?.cache);
 
-  const prefetchCacheTtlMs =
-    typeof init?.prefetchCacheTtlMs === 'number'
-      ? init.prefetchCacheTtlMs
-      : undefined;
+  const prefetchCacheTtlMs = validatePrefetchTtl(init?.prefetchCacheTtlMs);
 
   return {
     url,
@@ -408,8 +434,9 @@ export function buildNitroRequestPure(
     headers: headers.length > 0 ? headers : undefined,
     bodyString: normalized?.bodyString,
     bodyBytes: normalized?.bodyBytes,
-    followRedirects: true,
-    credentials: init?.credentials,
+    followRedirects:
+      (init?.redirect ?? inputRequest?.redirect ?? 'follow') === 'follow',
+    credentials: init?.credentials ?? inputRequest?.credentials,
     prefetchCacheTtlMs,
   };
 }
@@ -424,40 +451,64 @@ async function resolveRequestBody(
   input: RequestInfo | URL,
   init: RequestInit | undefined
 ): Promise<RequestInit | undefined> {
+  const request =
+    typeof input === 'object' && input !== null && 'url' in input
+      ? (input as Request)
+      : undefined;
+  const inputBody =
+    input instanceof NitroRequestClass
+      ? rawBodyOf(input)
+      : (request?.body ??
+        (request as { _bodyInit?: unknown } | undefined)?._bodyInit);
+  validateRequestBody(init?.method ?? request?.method, init?.body ?? inputBody);
   if (typeof input === 'string' || input instanceof URL) return init;
   if (input instanceof NitroRequestClass) {
-    const raw = rawBodyOf(input);
-    if (init?.body == null && raw != null)
+    if (init?.body != null) return init;
+    if (
+      typeof ReadableStream !== 'undefined' &&
+      rawBodyOf(input) instanceof ReadableStream
+    ) {
+      return {
+        ...(init ?? {}),
+        headers: init?.headers ?? (input.headers as any),
+        body: await input.arrayBuffer(),
+      };
+    }
+    const raw = consumeRawBodyOf(input);
+    if (raw != null) {
       return {
         ...(init ?? {}),
         headers: init?.headers ?? (input.headers as any),
         body: raw,
       };
+    }
     return init;
   }
   if (init?.body != null) return init;
   const req = input as Request;
+  if (req.bodyUsed)
+    throw new TypeError('Request body has already been consumed.');
   if (typeof req.clone !== 'function') return init;
   const method = (init?.method ?? req.method ?? 'GET').toUpperCase();
   if (method === 'GET' || method === 'HEAD') return init;
-  try {
-    // whatwg-fetch keeps the original BodyInit here; only bytes need the lossless read.
-    const raw = (req as { _bodyInit?: unknown })._bodyInit;
-    const isBinary =
-      (typeof Blob !== 'undefined' && raw instanceof Blob) ||
-      (typeof ArrayBuffer !== 'undefined' && raw instanceof ArrayBuffer) ||
-      ArrayBuffer.isView(raw);
-    if (isBinary && typeof req.arrayBuffer === 'function') {
-      const bytes = await req.clone().arrayBuffer();
-      if (bytes.byteLength === 0) return init;
-      return { ...(init ?? {}), body: bytes };
-    }
-    const text = await req.clone().text();
-    if (text.length === 0) return init;
-    return { ...(init ?? {}), body: text };
-  } catch {
-    return init;
+  // Read bytes when supported: a standard Request need not expose _bodyInit,
+  // and decoding an arbitrary binary body as text irreversibly changes it.
+  const raw = (req as { _bodyInit?: unknown })._bodyInit;
+  if (req.body === null || raw === null) return init;
+  if (isFormData(raw) && req instanceof Request) {
+    // RN's whatwg-fetch Request constructor transfers the opaque FormData
+    // body and marks its input consumed without trying to serialize it in JS.
+    const owned = new Request(req);
+    return {
+      ...(init ?? {}),
+      body: (owned as unknown as { _bodyInit: FormData })._bodyInit,
+    };
   }
+  if (typeof req.arrayBuffer === 'function') {
+    const bytes = await req.arrayBuffer();
+    return { ...(init ?? {}), body: bytes };
+  }
+  return { ...(init ?? {}), body: await req.text() };
 }
 
 async function resolveBlobBody(
@@ -466,12 +517,7 @@ async function resolveBlobBody(
   if (!init?.body) return init;
   if (typeof Blob !== 'undefined' && init.body instanceof Blob) {
     const blob = init.body as Blob;
-    const bytes = await new Promise<ArrayBuffer>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = () => reject(reader.error);
-      reader.readAsArrayBuffer(blob);
-    });
+    const bytes = await readBlob(blob);
     // Auto-set Content-Type from Blob.type if not already provided
     let headers = init.headers;
     if (blob.type) {
@@ -516,7 +562,11 @@ function base64ToBytes(b64: string): Uint8Array {
   /* eslint-disable no-bitwise */
   const chars =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-  const clean = b64.replace(/[^A-Za-z0-9+/]/g, '');
+  let clean = b64.replace(/[\t\n\f\r ]/g, '');
+  if (clean.length % 4 === 0) clean = clean.replace(/[=]{1,2}$/, '');
+  if (clean.length % 4 === 1 || /[^A-Za-z0-9+/]/.test(clean)) {
+    throw new TypeError('Failed to fetch: invalid base64 data');
+  }
   const out = new Uint8Array(Math.floor((clean.length * 3) / 4));
   let p = 0;
   let buf = 0;
@@ -591,10 +641,19 @@ function decodeUtf8(bytes: Uint8Array): string | null {
 
 // Decode a data: URL into a synthetic 200 response, entirely in JS.
 function decodeDataUrl(url: string): NitroResponseNative {
+  // URL serialization performs UTF-8 percent-encoding. Decode percent escapes
+  // as bytes below, not decodeURIComponent (which rejects non-UTF-8 payloads).
+  const parsed = new URL(url);
+  parsed.hash = '';
+  url = parsed.href;
   const comma = url.indexOf(',');
   if (comma < 0) throw new TypeError('Failed to fetch: invalid data: URL');
   const meta = url.slice(5, comma); // strip leading "data:"
-  const rawData = url.slice(comma + 1);
+  const rawData = url
+    .slice(comma + 1)
+    .replace(/%([0-9a-f]{2})/gi, (_, hex: string) =>
+      String.fromCharCode(parseInt(hex, 16))
+    );
   const isBase64 = /;base64\s*$/i.test(meta);
   const mediaType =
     (isBase64 ? meta.replace(/;base64\s*$/i, '') : meta).trim() ||
@@ -611,11 +670,11 @@ function decodeDataUrl(url: string): NitroResponseNative {
     const decoded = decodeUtf8(bytes);
     if (decoded != null) bodyString = decoded;
   } else {
-    bodyString = decodeURIComponent(rawData);
-    length =
-      typeof TextEncoder !== 'undefined'
-        ? new TextEncoder().encode(bodyString).length
-        : bodyString.length;
+    const bytes = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; i++) bytes[i] = rawData.charCodeAt(i);
+    bodyBytes = bytes.buffer;
+    bodyString = decodeUtf8(bytes) ?? undefined;
+    length = bytes.byteLength;
   }
 
   return {
@@ -638,7 +697,7 @@ async function fetchLocalResource(
   req: NitroRequestNative
 ): Promise<NitroResponseNative> {
   const url = req.url;
-  if (url.startsWith('data:')) return decodeDataUrl(url);
+  if (url.slice(0, 5).toLowerCase() === 'data:') return decodeDataUrl(url);
   if (url.startsWith('blob:')) {
     throw new TypeError(
       'nitro-fetch cannot read blob: URLs (the React Native blob registry is not ' +
@@ -663,17 +722,11 @@ async function nitroFetchRaw(
     throw createAbortError();
   }
 
-  // Extract body from standard Request when init.body is absent (ky/undici pattern)
-  init = await resolveRequestBody(input, init);
-  // Resolve Blob body to string before passing to sync buildNitroRequest
-  init = await resolveBlobBody(init);
-
   const hasNative =
     typeof (NitroFetchHybrid as any)?.createClient === 'function';
   if (!hasNative) {
-    // Fallback path not supported for raw; use global fetch and synthesize minimal shape
-    // @ts-ignore: global fetch exists in RN
-    const res = await fetch(input as any, init);
+    // Let the platform consume standard Request inputs exactly once.
+    const res = await platformFetch(input, init);
     const url = (res as any).url ?? String(input);
     const bytes = await res.arrayBuffer();
     const headers: NitroHeader[] = [];
@@ -687,8 +740,13 @@ async function nitroFetchRaw(
       headers,
       bodyBytes: bytes,
       bodyString: undefined,
-    } as any as NitroResponseNative; // bleee
+    } as NitroResponseNative;
   }
+
+  init = await resolveRequestBody(input, init);
+  init = await resolveBlobBody(init);
+  // Preparation yields to JS; an abort here must not dispatch native work.
+  if (signal?.aborted) throw createAbortError();
 
   const req = buildNitroRequest(input, init);
 
@@ -718,22 +776,29 @@ async function nitroFetchRaw(
   if (!client || typeof (client as any).request !== 'function')
     throw new Error('NitroFetch client not available');
 
-  // Wire up the abort listener with { once: true } so it auto-removes
-  // after firing, avoiding a dangling reference to the client closure.
   let abortListener: (() => void) | undefined;
-  if (signal && requestId) {
-    abortListener = () => {
-      try {
-        client!.cancelRequest(requestId);
-      } catch {
-        // Client may already be torn down — swallow.
-      }
-    };
-    signal.addEventListener('abort', abortListener, { once: true });
-  }
-
   try {
-    const res: NitroResponseNative = await client.request(req);
+    const res: NitroResponseNative = await (signal && requestId
+      ? new Promise<NitroResponseNative>((resolve, reject) => {
+          abortListener = () => {
+            // A request may be joining a prefetch, or native cancellation may
+            // race completion. Reject immediately without waiting for native.
+            reject(createAbortError());
+            try {
+              client!.cancelRequest(requestId);
+            } catch {
+              /* already torn down */
+            }
+          };
+          signal.addEventListener('abort', abortListener, { once: true });
+          if (signal.aborted) {
+            abortListener();
+            return;
+          }
+          Promise.resolve(client!.request(req)).then(resolve, reject);
+        })
+      : client.request(req));
+    if (signal?.aborted) throw createAbortError();
     if (inspectorId) {
       NetworkInspector._recordEnd(
         inspectorId,
@@ -822,31 +887,64 @@ async function nitroStreamFetch(
       abortListener = undefined;
     };
 
-    let streamCancelled = false;
+    let terminal = false;
+    let streamBytesReceived = 0;
+    let responseInfo: UrlResponseInfo | undefined;
+    let request: ReturnType<typeof builder.build> | undefined;
+    const finishInspection = (info = responseInfo, error?: string) => {
+      if (inspectorId) {
+        NetworkInspector._recordEnd(
+          inspectorId,
+          info?.httpStatusCode ?? 0,
+          info?.httpStatusText ?? '',
+          info?.allHeadersAsList ?? [],
+          streamBytesReceived,
+          error
+        );
+      }
+    };
+    const cancelNative = () => {
+      try {
+        request?.cancel();
+      } catch {
+        // The request may already be torn down.
+      }
+    };
     const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
       start(controller) {
         streamController = controller;
       },
       cancel() {
-        streamCancelled = true;
+        if (terminal) return;
+        terminal = true;
         cleanupAbortListener();
-        try {
-          request.cancel();
-        } catch {
-          return;
-        }
+        finishInspection(undefined, 'The operation was aborted.');
+        cancelNative();
       },
     });
 
     let responseResolved = false;
-    let streamBytesReceived = 0;
+    let redirected = false;
 
-    builder.onResponseStarted((info) => {
-      if (responseResolved || signal?.aborted) return;
-      responseResolved = true;
+    const fail = (error: Error) => {
+      if (terminal) return;
+      terminal = true;
+      cleanupAbortListener();
+      finishInspection(undefined, error.message);
+      if (!responseResolved) rejectResponse(error);
+      streamController.error(error);
+      cancelNative();
+    };
+
+    const resolve = (info: UrlResponseInfo, wasRedirected: boolean) => {
+      responseInfo = info;
       const status = info.httpStatusCode;
       const responseHeaders = new NitroHeaders(
-        Object.entries(info.allHeaders).map(([key, value]) => ({ key, value }))
+        info.allHeadersAsList ??
+          Object.entries(info.allHeaders).map(([key, value]) => ({
+            key,
+            value,
+          }))
       );
       const response = new NitroResponse({
         url: info.url,
@@ -854,93 +952,96 @@ async function nitroStreamFetch(
         status,
         statusText: info.httpStatusText,
         headers: responseHeaders,
-        redirected: false,
+        redirected: wasRedirected,
         body: stream,
       });
+      responseResolved = true;
       resolveResponse(response as unknown as Response);
+    };
+
+    builder.onRedirectReceived((info) => {
+      if (terminal) return;
+      if (init?.redirect === 'error') {
+        fail(new TypeError('Redirect encountered with redirect mode "error".'));
+      } else if (init?.redirect === 'manual') {
+        try {
+          resolve(info, false);
+          terminal = true;
+          cleanupAbortListener();
+          finishInspection(info);
+          streamController.close();
+          cancelNative();
+        } catch (error) {
+          fail(error as Error);
+        }
+      } else {
+        try {
+          redirected = true;
+          request?.followRedirect();
+        } catch (error) {
+          fail(error as Error);
+        }
+      }
+    });
+
+    builder.onResponseStarted((info) => {
+      if (terminal || responseResolved) return;
       // Android/Cronet: kick off the first buffer read.
       // iOS/URLSession handles reading automatically so this is a no-op there.
-      request.read();
+      try {
+        resolve(info, redirected);
+        request?.read();
+      } catch (error) {
+        fail(error as Error);
+      }
     });
 
     builder.onReadCompleted((_info, byteBuffer, bytesRead) => {
       // A cancelled stream can still receive an in-flight native read.
-      if (streamCancelled || signal?.aborted) return;
-      const chunk = new Uint8Array(byteBuffer, 0, bytesRead).slice();
-      streamBytesReceived += bytesRead;
-      streamController.enqueue(chunk);
-      if (!request.isDone()) {
-        request.read();
+      if (terminal) return;
+      try {
+        const chunk = new Uint8Array(byteBuffer, 0, bytesRead).slice();
+        streamBytesReceived += bytesRead;
+        streamController.enqueue(chunk);
+        if (request && !request.isDone()) request.read();
+      } catch (error) {
+        fail(error as Error);
       }
     });
 
     builder.onSucceeded((_info) => {
+      if (terminal) return;
+      terminal = true;
       cleanupAbortListener();
-      if (streamCancelled) return;
       streamController.close();
-      if (inspectorId) {
-        const info = _info as any;
-        const status = info?.httpStatusCode ?? 0;
-        const hdrs = info?.allHeadersAsList ?? [];
-        NetworkInspector._recordEnd(
-          inspectorId,
-          status,
-          info?.httpStatusText ?? '',
-          hdrs,
-          streamBytesReceived
-        );
-      }
+      finishInspection(_info);
     });
 
     builder.onFailed((_info, error) => {
-      cleanupAbortListener();
       const err = signal?.aborted
         ? createAbortError()
         : new Error(error.message);
-      if (inspectorId) {
-        NetworkInspector._recordEnd(inspectorId, 0, '', [], 0, error.message);
-      }
-      if (!responseResolved) {
-        responseResolved = true;
-        rejectResponse(err);
-      } else {
-        streamController.error(err);
-      }
+      fail(err);
     });
 
     builder.onCanceled(() => {
-      cleanupAbortListener();
-      const err = createAbortError();
-      if (inspectorId) {
-        NetworkInspector._recordEnd(
-          inspectorId,
-          0,
-          '',
-          [],
-          0,
-          'Request canceled'
-        );
-      }
-      if (!responseResolved) {
-        responseResolved = true;
-        rejectResponse(err);
-      } else {
-        streamController.error(err);
-      }
+      fail(createAbortError());
     });
 
-    const request = builder.build();
-    if (signal) {
-      abortListener = () => {
-        try {
-          request.cancel();
-        } catch {
+    try {
+      request = builder.build();
+      if (signal) {
+        abortListener = () => fail(createAbortError());
+        signal.addEventListener('abort', abortListener, { once: true });
+        if (signal.aborted) {
+          abortListener();
           return;
         }
-      };
-      signal.addEventListener('abort', abortListener, { once: true });
+      }
+      request.start();
+    } catch (error) {
+      fail(error as Error);
     }
-    request.start();
   });
 }
 
@@ -961,28 +1062,35 @@ export async function nitroFetch(
      * Nothing arrives early.
      *
      * Not a free upgrade: the streaming transport is a separate native client.
-     * It does not consult the prefetch cache, always reports
-     * `response.redirected === false`, and ignores `redirect: 'error'`.
+     * It does not consult the prefetch cache. On iOS, body delivery is
+     * push-based and does not apply backpressure to URLSession.
      *
      * @default false
      */
     stream?: boolean;
     redirect?: RequestRedirect;
     cache?: RequestCache;
+    prefetchCacheTtlMs?: number;
   }
 ): Promise<Response> {
-  // Merge defaults from NitroRequestClass if input is one
-  if (input instanceof NitroRequestClass) {
+  // Both standard and Nitro Request inputs carry defaults, including a signal.
+  if (typeof input === 'object' && input !== null && 'url' in input) {
     init = {
       ...init,
-      signal: init?.signal ?? input.signal,
+      signal: init?.signal !== undefined ? init.signal : input.signal,
       redirect: (init?.redirect as RequestRedirect) ?? input.redirect,
       cache: (init?.cache as RequestCache) ?? input.cache,
+      credentials: init?.credentials ?? input.credentials,
     } as any;
   }
 
   // Streaming is http(s)-only; local URLs fall through to nitroFetchRaw (check runs only when streaming).
-  if ((init as any)?.stream === true && isHttpUrl(getUrlString(input))) {
+  if (
+    (init as any)?.stream === true &&
+    typeof NitroFetchHybrid?.createClient === 'function' &&
+    isHttpUrl(getUrlString(input))
+  ) {
+    if (init?.signal?.aborted) throw createAbortError();
     init = await resolveRequestBody(input, init);
     init = await resolveBlobBody(init);
     return nitroStreamFetch(input, init);
@@ -1015,7 +1123,7 @@ export async function nitroFetch(
 // Start a native prefetch. Requires a `prefetchKey` header on the request.
 export async function prefetch(
   input: RequestInfo | URL,
-  init?: RequestInit
+  init?: RequestInit & { prefetchKey?: string; prefetchCacheTtlMs?: number }
 ): Promise<void> {
   // If native implementation is not present yet, do nothing
   const hasNative =
@@ -1055,7 +1163,7 @@ const AUTOPREFETCH_QUEUE_KEY = 'nitrofetch_autoprefetch_queue';
 // Entries embed request headers (may hold credentials) — stored encrypted at rest.
 export async function prefetchOnAppStart(
   input: RequestInfo | URL,
-  init?: RequestInit & { prefetchKey?: string }
+  init?: RequestInit & { prefetchKey?: string; prefetchCacheTtlMs?: number }
 ): Promise<void> {
   // Resolve request and prefetchKey
   init = await resolveRequestBody(input, init);

--- a/packages/react-native-nitro-fetch/src/index.web.tsx
+++ b/packages/react-native-nitro-fetch/src/index.web.tsx
@@ -2,7 +2,8 @@
 // Native (Cronet/URLSession) is unavailable on the web, so we delegate to the
 // browser's built-in fetch and stub native-only APIs with console.warn.
 
-import { NitroRequest as NitroRequestClass } from './Request';
+import { platformFetch } from './platformFetch';
+import { utf8ToString } from './utf8';
 import type { RequestRedirect, RequestCache } from './Request';
 
 export { NitroHeaders as Headers } from './Headers';
@@ -57,31 +58,10 @@ export async function fetch(
     stream?: boolean;
     redirect?: RequestRedirect;
     cache?: RequestCache;
+    prefetchCacheTtlMs?: number;
   }
 ): Promise<Response> {
-  let resolvedInput: RequestInfo | URL = input;
-  let resolvedInit = init;
-  if (input instanceof NitroRequestClass) {
-    const method = (init?.method ?? input.method).toUpperCase();
-    const hasBodyMethod = method !== 'GET' && method !== 'HEAD';
-    let body: BodyInit | null | undefined = init?.body;
-    if (body === undefined && hasBodyMethod) {
-      const bytes = await input.arrayBuffer().catch(() => undefined);
-      body = bytes && bytes.byteLength > 0 ? bytes : null;
-    }
-    resolvedInput = input.url;
-    resolvedInit = {
-      ...init,
-      method,
-      headers: (init?.headers ??
-        (input.headers as unknown as HeadersInit)) as HeadersInit,
-      body,
-      redirect: init?.redirect ?? input.redirect,
-      cache: init?.cache ?? input.cache,
-      signal: init?.signal ?? input.signal,
-    };
-  }
-  return globalThis.fetch(resolvedInput as RequestInfo, resolvedInit);
+  return platformFetch(input, init);
 }
 
 export type NitroWorkletMapper<T> = (payload: {
@@ -104,11 +84,11 @@ export async function nitroFetchOnWorklet<T>(
   console.warn(
     'nitroFetchOnWorklet: worklets are not available on web; running on the JS thread'
   );
-  const res = await globalThis.fetch(input as RequestInfo, init);
-  const bodyBytes = await res.clone().arrayBuffer();
+  const res = await fetch(input, init);
+  const bodyBytes = await res.arrayBuffer();
   let bodyString: string | undefined;
   try {
-    bodyString = await res.clone().text();
+    bodyString = utf8ToString(new Uint8Array(bodyBytes));
   } catch {
     bodyString = undefined;
   }
@@ -128,14 +108,14 @@ export async function nitroFetchOnWorklet<T>(
 
 export async function prefetch(
   _input: RequestInfo | URL,
-  _init?: RequestInit
+  _init?: RequestInit & { prefetchKey?: string; prefetchCacheTtlMs?: number }
 ): Promise<void> {
   console.warn('prefetch is not available on web');
 }
 
 export async function prefetchOnAppStart(
   _input: RequestInfo | URL,
-  _init?: RequestInit & { prefetchKey?: string }
+  _init?: RequestInit & { prefetchKey?: string; prefetchCacheTtlMs?: number }
 ): Promise<void> {
   console.warn('prefetchOnAppStart is not available on web');
 }

--- a/packages/react-native-nitro-fetch/src/platformFetch.ts
+++ b/packages/react-native-nitro-fetch/src/platformFetch.ts
@@ -1,0 +1,31 @@
+import { NitroRequest, consumeRawBodyOf, rawBodyOf } from './Request';
+
+/** Preserve platform Request handling, including opaque RN FormData bodies. */
+export async function platformFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  if (!(input instanceof NitroRequest)) return globalThis.fetch(input, init);
+
+  const request = new NitroRequest(input, init);
+  const raw = rawBodyOf(request);
+  const body =
+    typeof ReadableStream !== 'undefined' && raw instanceof ReadableStream
+      ? await request.arrayBuffer()
+      : consumeRawBodyOf(request);
+  return globalThis.fetch(request.url, {
+    ...init,
+    method: request.method,
+    headers: request.headers as unknown as HeadersInit,
+    body,
+    signal: request.signal,
+    redirect: request.redirect,
+    cache: request.cache,
+    credentials: request.credentials,
+    mode: request.mode,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+  });
+}

--- a/packages/react-native-nitro-fetch/src/utf8.ts
+++ b/packages/react-native-nitro-fetch/src/utf8.ts
@@ -1,5 +1,5 @@
-let _TextEncoder: typeof TextEncoder | undefined;
-let _TextDecoder: typeof TextDecoder | undefined;
+let encoder: TextEncoder | undefined;
+let decoder: TextDecoder | undefined;
 
 const NITRO_TEXT_DECODER_PKG = 'react-native-nitro-text-decoder';
 
@@ -8,11 +8,9 @@ function loadOptionalTextCodec(): {
   TextDecoder?: typeof TextDecoder;
 } {
   try {
-    // Hide require from the bundler so the package stays truly optional.
-    // eslint-disable-next-line no-new-func
-    const dynamicRequire = new Function('mod', 'return require(mod);') as (
-      m: string
-    ) => unknown;
+    // Keep the dependency optional without runtime code generation. Apps
+    // using Metro should install global codecs explicitly when needed.
+    const dynamicRequire = require;
     return dynamicRequire(NITRO_TEXT_DECODER_PKG) as {
       TextEncoder?: typeof TextEncoder;
       TextDecoder?: typeof TextDecoder;
@@ -22,34 +20,33 @@ function loadOptionalTextCodec(): {
   }
 }
 
-if (typeof TextEncoder !== 'undefined') {
-  _TextEncoder = TextEncoder;
-} else {
-  _TextEncoder = loadOptionalTextCodec().TextEncoder;
-}
-
-if (typeof TextDecoder !== 'undefined') {
-  _TextDecoder = TextDecoder;
-} else {
-  _TextDecoder = loadOptionalTextCodec().TextDecoder;
-}
-
 export function stringToUTF8(str: string): Uint8Array {
-  if (!_TextEncoder) {
-    console.warn(
-      'stringToUTF8: TextEncoder not available. Install react-native-nitro-text-decoder.'
-    );
-    return new Uint8Array(0);
+  if (str.length === 0) return new Uint8Array(0);
+  if (!encoder) {
+    const Encoder =
+      globalThis.TextEncoder ?? loadOptionalTextCodec().TextEncoder;
+    if (!Encoder) {
+      throw new TypeError(
+        'TextEncoder is unavailable; install a UTF-8 codec polyfill.'
+      );
+    }
+    encoder = new Encoder();
   }
-  return new _TextEncoder().encode(str);
+  return encoder.encode(str);
 }
 
 export function utf8ToString(bytes: Uint8Array): string {
-  if (!_TextDecoder) {
-    console.warn(
-      'utf8ToString: TextDecoder not available. Install react-native-nitro-text-decoder.'
-    );
-    return '';
+  if (bytes.byteLength === 0) return '';
+  if (!decoder) {
+    const Decoder =
+      globalThis.TextDecoder ?? loadOptionalTextCodec().TextDecoder;
+    if (!Decoder) {
+      throw new TypeError(
+        'TextDecoder is unavailable; install a UTF-8 codec polyfill.'
+      );
+    }
+    decoder = new Decoder();
   }
-  return new _TextDecoder().decode(bytes);
+  // Non-streaming decode resets decoder state between independent bodies.
+  return decoder.decode(bytes);
 }


### PR DESCRIPTION
## Fixes

- Share body consumption/clone logic across Request and Response; support Blob, streams and URLSearchParams without silently dropping payloads.
- Preserve RequestInit overrides, native and platform Request consumption, HTTP aborts, and streaming redirect decisions.
- Preserve original non-UTF-8 response bytes; reuse UTF-8 codecs without runtime code generation; correct binary data URLs and BOM text decoding.
- Register native requests before start/completion can race; make iOS prefetch await/join/error behavior real; use monotonic, finite cache TTLs.
- Remove duplicated iOS response-building and unused method/final-URL wrappers.

## Compatibility / breaking changes

- Consumed/locked body reuse, invalid GET/HEAD bodies, invalid public Response construction, empty/undefined JSON, and unsupported FormData serialization now reject. Native FormData uploads remain supported.
- text()/json() decode UTF-8 rather than interpreting a legacy charset header; byte readers preserve the original payload. Missing non-empty UTF-8 conversion now throws; install global codecs when needed.
- iOS await prefetch() now waits and can reject. Non-finite prefetchCacheTtlMs rejects; zero/negative TTL skips completed cached responses, not in-flight joining.
- Native manual redirects expose 3xx responses; browser manual redirects retain platform behavior. No package version or dependency upgrade is included.

## Verification

- Existing Jest and Bun suites: 10 passing, 2 existing TODOs. TypeScript, ESLint (one unrelated existing WebSocket plugin warning), Nitrogen and Bob build pass.
- Focused external diagnostic harnesses cover body readers/clones/locks, Request transfer, platform fallback, data URLs, abort/redirect callbacks, validation and codecs. Real Foundation URLSession loopback checks: 13/13; Swift streaming callbacks: 5/5.
- Android example Debug and iOS example Release builds pass, including tracing-enabled builds; iOS Simulator launch verified. React Doctor changed-source scan: 100/100, no issues.
- The complete combined candidate was tested locally; this PR excludes independent Headers, inspector, storage, logging, Expo and podspec fixes. No test/spec files are added or modified.

Fixes #183. Fixes #185. Fixes #186. Fixes #188. Fixes #189. Fixes #190. Fixes #196. Fixes #197. Fixes #200. Fixes #201. Fixes #203. Fixes #206.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
