### PR TITLE
fix: normalize Headers and preserve live, isolated iteration

### DIFF
--- a/packages/react-native-nitro-fetch/src/Headers.ts
+++ b/packages/react-native-nitro-fetch/src/Headers.ts
@@ -9,11 +9,24 @@ type HeadersInitInput =
   | undefined;
 
 function normalizeName(name: string): string {
-  return name.toLowerCase();
+  const value = String(name);
+  if (!/^[!#$%&'*+.^_`|~0-9a-z-]+$/i.test(value)) {
+    throw new TypeError('Invalid header name.');
+  }
+  return value.toLowerCase();
+}
+
+function normalizeValue(value: string): string {
+  const normalized = String(value).replace(/^[\t\n\r ]+|[\t\n\r ]+$/g, '');
+  if (/[\0\r\n\u0100-\uffff]/.test(normalized)) {
+    throw new TypeError('Invalid header value.');
+  }
+  return normalized;
 }
 
 export class NitroHeaders {
   private _map: Map<string, string[]>;
+  private _sortedEntries: [string, string][] | undefined;
 
   constructor(init?: HeadersInitInput) {
     this._map = new Map();
@@ -31,17 +44,13 @@ export class NitroHeaders {
     ) {
       // Headers-like object (standard Headers or duck-typed)
       (init as any).forEach((value: string, key: string) => {
-        this._map.set(normalizeName(key), [value]);
+        this.append(key, value);
       });
     } else if (Array.isArray(init)) {
       for (const entry of init) {
-        if (Array.isArray(entry) && entry.length >= 2) {
+        if (Array.isArray(entry) && entry.length === 2) {
           // [string, string] tuple
-          const key = normalizeName(String(entry[0]));
-          const value = String(entry[1]);
-          const existing = this._map.get(key);
-          if (existing) existing.push(value);
-          else this._map.set(key, [value]);
+          this.append(entry[0], entry[1]);
         } else if (
           entry &&
           typeof entry === 'object' &&
@@ -49,11 +58,9 @@ export class NitroHeaders {
           'value' in entry
         ) {
           // NitroHeader object
-          const key = normalizeName((entry as NitroHeader).key);
-          const value = (entry as NitroHeader).value;
-          const existing = this._map.get(key);
-          if (existing) existing.push(value);
-          else this._map.set(key, [value]);
+          this.append(entry.key, entry.value);
+        } else {
+          throw new TypeError('Headers entries must contain a name and value.');
         }
       }
     } else if (typeof init === 'object' && init !== null) {
@@ -61,22 +68,24 @@ export class NitroHeaders {
       for (let i = 0; i < keys.length; i++) {
         const k = keys[i]!;
         const v = (init as Record<string, string>)[k];
-        if (v !== undefined) {
-          this._map.set(normalizeName(k), [String(v)]);
-        }
+        this.append(k, String(v));
       }
     }
   }
 
   append(name: string, value: string): void {
     const key = normalizeName(name);
+    const normalized = normalizeValue(value);
     const existing = this._map.get(key);
-    if (existing) existing.push(value);
-    else this._map.set(key, [value]);
+    if (existing) existing.push(normalized);
+    else this._map.set(key, [normalized]);
+    this._sortedEntries = undefined;
   }
 
   delete(name: string): void {
-    this._map.delete(normalizeName(name));
+    if (this._map.delete(normalizeName(name))) {
+      this._sortedEntries = undefined;
+    }
   }
 
   get(name: string): string | null {
@@ -86,7 +95,7 @@ export class NitroHeaders {
   }
 
   getSetCookie(): string[] {
-    return this._map.get('set-cookie') ?? [];
+    return [...(this._map.get('set-cookie') ?? [])];
   }
 
   has(name: string): boolean {
@@ -94,35 +103,50 @@ export class NitroHeaders {
   }
 
   set(name: string, value: string): void {
-    this._map.set(normalizeName(name), [value]);
+    this._map.set(normalizeName(name), [normalizeValue(value)]);
+    this._sortedEntries = undefined;
+  }
+
+  private _entries(): [string, string][] {
+    if (this._sortedEntries) return this._sortedEntries;
+    const entries: [string, string][] = [];
+    for (const key of Array.from(this._map.keys()).sort()) {
+      const values = this._map.get(key)!;
+      if (key === 'set-cookie') {
+        for (const value of values) entries.push([key, value]);
+      } else {
+        entries.push([key, values.join(', ')]);
+      }
+    }
+    this._sortedEntries = entries;
+    return entries;
   }
 
   forEach(
     callback: (value: string, key: string, headers: NitroHeaders) => void,
     thisArg?: any
   ): void {
-    const sortedKeys = Array.from(this._map.keys()).sort();
-    for (const key of sortedKeys) {
-      callback.call(thisArg, this._map.get(key)!.join(', '), key, this);
+    for (const [key, value] of this.entries()) {
+      callback.call(thisArg, value, key, this);
     }
   }
 
   entries(): HeadersIterator<[string, string]> {
-    const map = this._map;
-    const sortedKeys = Array.from(map.keys()).sort();
-    function* gen(): Generator<[string, string]> {
-      for (const key of sortedKeys) {
-        yield [key, map.get(key)!.join(', ')];
+    function* gen(headers: NitroHeaders): Generator<[string, string]> {
+      for (let index = 0; ; index++) {
+        // Re-read after a mutation: Headers iterators are live, not snapshots.
+        const entry = headers._entries()[index];
+        if (!entry) return;
+        yield [entry[0], entry[1]];
       }
     }
-    return gen() as unknown as HeadersIterator<[string, string]>;
+    return gen(this) as unknown as HeadersIterator<[string, string]>;
   }
 
   keys(): HeadersIterator<string> {
-    const map = this._map;
-    const sortedKeys = Array.from(map.keys()).sort();
+    const entries = this.entries();
     function* gen(): Generator<string> {
-      for (const key of sortedKeys) {
+      for (const [key] of entries) {
         yield key;
       }
     }
@@ -130,11 +154,10 @@ export class NitroHeaders {
   }
 
   values(): HeadersIterator<string> {
-    const map = this._map;
-    const sortedKeys = Array.from(map.keys()).sort();
+    const entries = this.entries();
     function* gen(): Generator<string> {
-      for (const key of sortedKeys) {
-        yield map.get(key)!.join(', ');
+      for (const [, value] of entries) {
+        yield value;
       }
     }
     return gen() as unknown as HeadersIterator<string>;


### PR DESCRIPTION
## Fixes

- Centralize name/value validation and coercion across constructors and mutators.
- Combine case-insensitive record keys, preserve separate Set-Cookie entries, and return an isolated cookie array.
- Keep iteration live across mutations and cache sorted entries until the next mutation; unchanged repeated iteration avoids re-sorting.

## Compatibility / breaking changes

- Malformed header names/values and tuples now throw TypeError. Leading/trailing HTTP whitespace is normalized; record values are string-coerced.
- getSetCookie() no longer exposes mutable internal storage. Mutation during iteration now follows live Headers ordering.

## Verification

- Focused platform Headers comparisons and mutation/clone regressions pass. Sixty unchanged iterations require one sort rather than sixty.
- TypeScript, ESLint and package builds pass on the combined candidate. No test files changed.

Fixes #184. Fixes #202.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
