### PR TITLE
fix: share token-refresh types and literal template helpers

### DIFF
--- a/packages/react-native-nitro-fetch/src/index.web.tsx
+++ b/packages/react-native-nitro-fetch/src/index.web.tsx
@@ -200,5 +200,5 @@ export function getNestedField(
 }
 
 export function applyTemplate(template: string, value: string): string {
-  return template.replace(/\{\{value\}\}/g, value);
+  return template.replace(/\{\{value\}\}/g, () => value);
 }

--- a/packages/react-native-nitro-fetch/src/index.web.tsx
+++ b/packages/react-native-nitro-fetch/src/index.web.tsx
@@ -4,6 +4,9 @@
 
 import { NitroRequest as NitroRequestClass } from './Request';
 import type { RequestRedirect, RequestCache } from './Request';
+import type { TokenRefreshConfig } from './tokenRefreshConfig';
+export type { TokenRefreshConfig } from './tokenRefreshConfig';
+export { getNestedField, applyTemplate } from './tokenRefreshConfig';
 
 export { NitroHeaders as Headers } from './Headers';
 export { NitroResponse as Response } from './Response';
@@ -28,24 +31,6 @@ export type {
   NitroRequest as NitroRequest,
   NitroResponse as NitroResponse,
 } from './NitroFetch.nitro';
-
-export type TokenRefreshConfig = {
-  url: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
-  headers?: Record<string, string>;
-  body?: string;
-  responseType?: 'json' | 'text';
-  mappings?: {
-    jsonPath: string;
-    header: string;
-    valueTemplate?: string;
-  }[];
-  compositeHeaders?: {
-    header: string;
-    template: string;
-    paths: Record<string, string>;
-  }[];
-};
 
 export async function fetch(
   input: RequestInfo | URL,
@@ -184,21 +169,4 @@ export function getStoredTokenRefreshConfig(
 ): TokenRefreshConfig | null {
   console.warn('getStoredTokenRefreshConfig is not available on web');
   return null;
-}
-
-export function getNestedField(
-  obj: unknown,
-  dotPath: string
-): string | undefined {
-  const parts = dotPath.split('.');
-  let current: unknown = obj;
-  for (const part of parts) {
-    if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[part];
-  }
-  return current != null ? String(current) : undefined;
-}
-
-export function applyTemplate(template: string, value: string): string {
-  return template.replace(/\{\{value\}\}/g, () => value);
 }

--- a/packages/react-native-nitro-fetch/src/tokenRefresh.ts
+++ b/packages/react-native-nitro-fetch/src/tokenRefresh.ts
@@ -1,4 +1,12 @@
 import { NativeStorage as NativeStorageSingleton } from './NitroInstances';
+import {
+  getNestedField,
+  applyTemplate,
+  applyCompositeTemplate,
+} from './tokenRefreshConfig';
+import type { TokenRefreshConfig } from './tokenRefreshConfig';
+export { getNestedField, applyTemplate } from './tokenRefreshConfig';
+export type { TokenRefreshConfig } from './tokenRefreshConfig';
 
 // Storage keys
 const KEY_WS = 'nitro_token_refresh_websocket';
@@ -7,79 +15,6 @@ const KEY_WS_CACHE = 'nitro_token_refresh_ws_cache';
 const KEY_FETCH_CACHE = 'nitro_token_refresh_fetch_cache';
 
 type TokenRefreshTarget = 'websocket' | 'fetch' | 'all';
-
-type TokenRefreshJsonMapping = {
-  jsonPath: string;
-  header: string;
-  valueTemplate?: string;
-};
-
-type TokenRefreshCompositeHeader = {
-  header: string;
-  template: string;
-  paths: Record<string, string>;
-};
-
-type TokenRefreshBodyMapping = {
-  jsonPath: string;
-  bodyPath: string;
-  valueTemplate?: string;
-};
-
-type TokenRefreshFormDataMapping = {
-  jsonPath: string;
-  field: string;
-  valueTemplate?: string;
-};
-
-export type TokenRefreshConfig = {
-  url: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
-  headers?: Record<string, string>;
-  body?: string;
-  responseType?: 'json' | 'text';
-  mappings?: TokenRefreshJsonMapping[];
-  compositeHeaders?: TokenRefreshCompositeHeader[];
-  textHeader?: string;
-  textTemplate?: string;
-  bodyMappings?: TokenRefreshBodyMapping[];
-  formDataMappings?: TokenRefreshFormDataMapping[];
-  bodyTextPath?: string;
-  formDataTextField?: string;
-  onFailure?: 'skip' | 'useStoredHeaders';
-};
-
-// — Helpers —
-
-/**
- * Resolve a dot-notation path inside a parsed JSON object.
- */
-export function getNestedField(
-  obj: unknown,
-  dotPath: string
-): string | undefined {
-  const parts = dotPath.split('.');
-  let current: unknown = obj;
-  for (const part of parts) {
-    if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[part];
-  }
-  return current != null ? String(current) : undefined;
-}
-
-export function applyTemplate(template: string, value: string): string {
-  return template.replace(/\{\{value\}\}/g, () => value);
-}
-
-function applyCompositeTemplate(
-  template: string,
-  values: Record<string, string>
-): string {
-  return template.replace(
-    /\{\{(\w+)\}\}/g,
-    (_: string, key: string) => values[key] ?? ''
-  );
-}
 
 export async function callRefreshEndpoint(
   config: TokenRefreshConfig
@@ -125,10 +60,9 @@ export async function callRefreshEndpoint(
 
   if (config.compositeHeaders) {
     for (const comp of config.compositeHeaders) {
-      const values: Record<string, string> = {};
+      const values: Record<string, string> = Object.create(null);
       for (const [placeholder, jsonPath] of Object.entries(comp.paths)) {
-        const val = getNestedField(json, jsonPath);
-        if (val != null) values[placeholder] = val;
+        values[placeholder] = getNestedField(json, jsonPath) ?? '';
       }
       headers[comp.header] = applyCompositeTemplate(comp.template, values);
     }

--- a/packages/react-native-nitro-fetch/src/tokenRefresh.ts
+++ b/packages/react-native-nitro-fetch/src/tokenRefresh.ts
@@ -68,7 +68,7 @@ export function getNestedField(
 }
 
 export function applyTemplate(template: string, value: string): string {
-  return template.replace(/\{\{value\}\}/g, value);
+  return template.replace(/\{\{value\}\}/g, () => value);
 }
 
 function applyCompositeTemplate(

--- a/packages/react-native-nitro-fetch/src/tokenRefreshConfig.ts
+++ b/packages/react-native-nitro-fetch/src/tokenRefreshConfig.ts
@@ -1,0 +1,71 @@
+type TokenRefreshJsonMapping = {
+  jsonPath: string;
+  header: string;
+  valueTemplate?: string;
+};
+
+type TokenRefreshCompositeHeader = {
+  header: string;
+  template: string;
+  paths: Record<string, string>;
+};
+
+type TokenRefreshBodyMapping = {
+  jsonPath: string;
+  bodyPath: string;
+  valueTemplate?: string;
+};
+
+type TokenRefreshFormDataMapping = {
+  jsonPath: string;
+  field: string;
+  valueTemplate?: string;
+};
+
+export type TokenRefreshConfig = {
+  url: string;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
+  headers?: Record<string, string>;
+  body?: string;
+  responseType?: 'json' | 'text';
+  mappings?: TokenRefreshJsonMapping[];
+  compositeHeaders?: TokenRefreshCompositeHeader[];
+  textHeader?: string;
+  textTemplate?: string;
+  bodyMappings?: TokenRefreshBodyMapping[];
+  formDataMappings?: TokenRefreshFormDataMapping[];
+  bodyTextPath?: string;
+  formDataTextField?: string;
+  onFailure?: 'skip' | 'useStoredHeaders';
+};
+
+// — Helpers —
+
+/**
+ * Resolve a dot-notation path inside a parsed JSON object.
+ */
+export function getNestedField(
+  obj: unknown,
+  dotPath: string
+): string | undefined {
+  const parts = dotPath.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current != null ? String(current) : undefined;
+}
+
+export function applyTemplate(template: string, value: string): string {
+  return template.replace(/\{\{value\}\}/g, () => value);
+}
+
+export function applyCompositeTemplate(
+  template: string,
+  values: Record<string, string>
+): string {
+  return template.replace(/\{\{([^{}]+)\}\}/g, (match: string, key: string) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? values[key]! : match
+  );
+}


### PR DESCRIPTION
## Fixes

- Share platform-neutral token-refresh configuration and helper implementations between native and web, without importing NitroInstances on web.
- Include all native configuration fields in web types, including text/body/form-data mappings and onFailure. Web cold-start APIs remain no-ops.
- Insert dollar sequences literally; process composite placeholders in one pass, support configured hyphenated/prototype-named placeholders and avoid inherited-property lookups.

## Compatibility / breaking changes

- Inserted values are never treated as replacement-string syntax or re-expanded.
- Unknown/unconfigured composite placeholders now remain literal in JS, matching native behavior; configured missing/null values still become empty.
- Existing public exports and native runtime entrypoints are preserved; no new dependency or version bump.

## Verification

- Ten external JS cases pass: shared helper identity, dollar sequences, arrays/null/booleans, cross-referencing tokens, missing/unknown/non-word/prototype-named placeholders and Unicode.
- TypeScript, ESLint and module/declaration builds pass. Shared configuration contains no native imports.
- No test/spec files added or modified. Native bootstrap corrections are submitted separately.

Fixes #187. Fixes #219.

### Consumer follow-up verification

The combined fixes are backported to an immutable 1.6.1 artifact. Both consuming app Android Debug variants, both iOS Debug Simulator variants, four production Metro bundles, 13 web targets, four browser-extension builds, lint and immutable installation pass. All 274 installed non-metadata files match the artifact. This is build verification, not a physical-device authentication/upload certification.
