### PR TITLE
fix: bound inspector history and preserve diagnostic behavior

### DIFF
--- a/docs-website/docs/inspection.md
+++ b/docs-website/docs/inspection.md
@@ -21,7 +21,8 @@ NetworkInspector.enable();
 // Optionally configure limits
 NetworkInspector.enable({
   maxEntries: 500,      // ring-buffer size (default 500)
-  maxBodyCapture: 4096, // max bytes captured per body (default 4096)
+  maxBodyCapture: 4096, // max UTF-16 code units captured per body (default 4096)
+  maxMessagesPerSocket: 100, // retained messages per WebSocket (default 100)
 });
 
 // Stop recording
@@ -29,6 +30,8 @@ NetworkInspector.disable();
 ```
 
 Once enabled, **all `fetch()` calls** are automatically recorded. WebSocket tracking is also automatic if `react-native-nitro-websockets` is installed alongside `react-native-nitro-fetch`.
+
+Limits must be non-negative safe integers. Lowering `maxEntries` or `maxMessagesPerSocket` trims existing history immediately. Socket message/byte totals remain cumulative after old message details are discarded. Reducing `maxBodyCapture` affects future captures. Inspector-generated curl commands use the captured body and explicitly mark truncation; standalone `generateCurl` preserves the supplied body, including empty and long bodies.
 
 ### Reading entries
 

--- a/packages/react-native-nitro-fetch/src/CurlGenerator.ts
+++ b/packages/react-native-nitro-fetch/src/CurlGenerator.ts
@@ -15,7 +15,7 @@ function shellEscape(str: string): string {
 export function generateCurl(options: CurlOptions): string {
   const parts: string[] = ['curl'];
 
-  if (options.method && options.method !== 'GET') {
+  if (options.method && (options.method !== 'GET' || options.body != null)) {
     parts.push('-X', shellEscape(options.method));
   }
 
@@ -26,19 +26,14 @@ export function generateCurl(options: CurlOptions): string {
     }
   }
 
-  if (options.body) {
-    const maxLen = 10_000;
-    const truncated =
-      options.body.length > maxLen
-        ? options.body.slice(0, maxLen) + '...[truncated]'
-        : options.body;
-    parts.push('-d', shellEscape(truncated));
+  if (options.body != null) {
+    parts.push('--data-raw', shellEscape(options.body));
   }
 
   if (options.verbose) parts.push('-v');
   if (options.compressed) parts.push('--compressed');
 
-  parts.push(shellEscape(options.url));
+  parts.push('--url', shellEscape(options.url));
 
   return parts.join(' ');
 }

--- a/packages/react-native-nitro-fetch/src/HermesProfiler.ts
+++ b/packages/react-native-nitro-fetch/src/HermesProfiler.ts
@@ -1,10 +1,10 @@
-declare const global: {
-  HermesInternal?: {
-    enableSamplingProfiler(): void;
-    disableSamplingProfiler(): void;
-    dumpSamplingProfiler(filename: string): void;
-  };
-};
+interface SamplingProfiler {
+  enableSamplingProfiler(): void;
+  disableSamplingProfiler(): void;
+  dumpSamplingProfiler(filename: string): void;
+}
+
+let profiling = false;
 
 export interface ProfileResult<T> {
   result: T;
@@ -15,23 +15,42 @@ export async function profileFetch<T>(
   fn: () => Promise<T>,
   outputPath?: string
 ): Promise<ProfileResult<T>> {
-  const hermes = global.HermesInternal;
-  if (!hermes) {
+  const hermes = (
+    globalThis as typeof globalThis & {
+      HermesInternal?: Partial<SamplingProfiler>;
+    }
+  ).HermesInternal;
+  if (
+    profiling ||
+    typeof hermes?.enableSamplingProfiler !== 'function' ||
+    typeof hermes.disableSamplingProfiler !== 'function' ||
+    typeof hermes.dumpSamplingProfiler !== 'function'
+  ) {
     const result = await fn();
     return { result };
   }
 
   const path = outputPath ?? `/tmp/nitrofetch-profile-${Date.now()}.cpuprofile`;
-  hermes.enableSamplingProfiler();
   try {
-    const result = await fn();
-    return { result, profilePath: path };
+    hermes.enableSamplingProfiler();
+  } catch {
+    return { result: await fn() };
+  }
+  profiling = true;
+  let result: T;
+  let profilePath: string | undefined;
+  try {
+    result = await fn();
   } finally {
-    hermes.disableSamplingProfiler();
     try {
+      hermes.disableSamplingProfiler();
       hermes.dumpSamplingProfiler(path);
+      profilePath = path;
     } catch {
-      // Profile dump may fail on some platforms
+      // Diagnostics must not change the wrapped function's result or error.
+    } finally {
+      profiling = false;
     }
   }
+  return profilePath ? { result, profilePath } : { result };
 }

--- a/packages/react-native-nitro-fetch/src/NetworkInspector.ts
+++ b/packages/react-native-nitro-fetch/src/NetworkInspector.ts
@@ -57,13 +57,30 @@ class NetworkInspectorImpl {
   private _entries: InspectorEntry[] = [];
   private _maxEntries: number = 500;
   private _maxBodyCapture: number = 4096;
+  private _maxMessagesPerSocket: number = 100;
   private _listeners: Set<NetworkEntryCallback> = new Set();
 
-  enable(options?: { maxEntries?: number; maxBodyCapture?: number }): void {
+  enable(options?: {
+    maxEntries?: number;
+    maxBodyCapture?: number;
+    maxMessagesPerSocket?: number;
+  }): void {
+    for (const [name, value] of Object.entries(options ?? {})) {
+      if (value != null && (!Number.isSafeInteger(value) || value < 0)) {
+        throw new RangeError(`${name} must be a non-negative safe integer.`);
+      }
+    }
     this._enabled = true;
     if (options?.maxEntries != null) this._maxEntries = options.maxEntries;
     if (options?.maxBodyCapture != null)
       this._maxBodyCapture = options.maxBodyCapture;
+    if (options?.maxMessagesPerSocket != null) {
+      this._maxMessagesPerSocket = options.maxMessagesPerSocket;
+      for (const entry of this._entries) {
+        if (entry.type === 'websocket') this._trimMessages(entry);
+      }
+    }
+    this._trimEntries();
   }
 
   disable(): void {
@@ -115,7 +132,16 @@ class NetworkInspectorImpl {
 
   private _trimEntries(): void {
     if (this._entries.length > this._maxEntries) {
-      this._entries.shift();
+      this._entries.splice(0, this._entries.length - this._maxEntries);
+    }
+  }
+
+  private _trimMessages(entry: WebSocketEntry): void {
+    if (entry.messages.length > this._maxMessagesPerSocket) {
+      entry.messages.splice(
+        0,
+        entry.messages.length - this._maxMessagesPerSocket
+      );
     }
   }
 
@@ -130,13 +156,14 @@ class NetworkInspectorImpl {
   ): void {
     if (!this._enabled) return;
     const bodySize = body ? body.length : 0;
+    const capturedBody = body?.slice(0, this._maxBodyCapture);
     const entry: NetworkEntry = {
       id,
       type: 'http',
       url,
       method,
       requestHeaders: headers.map((h) => ({ key: h.key, value: h.value })),
-      requestBody: body ? body.slice(0, this._maxBodyCapture) : undefined,
+      requestBody: capturedBody,
       requestBodySize: bodySize,
       status: 0,
       statusText: '',
@@ -145,7 +172,11 @@ class NetworkInspectorImpl {
       startTime: performance.now(),
       endTime: 0,
       duration: 0,
-      curl: generateCurl({ url, method, headers, body }),
+      curl:
+        generateCurl({ url, method, headers, body: capturedBody }) +
+        (bodySize > this._maxBodyCapture
+          ? ' # Request body truncated by maxBodyCapture; not a complete reproduction.'
+          : ''),
     };
     this._entries.push(entry);
     this._trimEntries();
@@ -240,6 +271,7 @@ class NetworkInspectorImpl {
       isBinary,
       timestamp: performance.now(),
     });
+    this._trimMessages(entry);
     if (direction === 'sent') {
       entry.messagesSent++;
       entry.bytesSent += size;


### PR DESCRIPTION
## Fixes

- Bound retained WebSocket messages per connection, trim history when limits shrink, preserve cumulative counters and reject invalid limits.
- Use the captured request body in inspector curl output with explicit truncation notes; standalone curl generation preserves empty/long/literal bodies and explicit URL/method arguments.
- Make Hermes profiling best-effort, protect nested ownership, and preserve the wrapped result/error when profiler APIs are absent or fail.

## Compatibility / breaking changes

- maxMessagesPerSocket defaults to 100. Limits must be non-negative safe integers; shrinking entry/message limits immediately trims existing history.
- Inspector curl output obeys maxBodyCapture (UTF-16 code units); standalone generateCurl no longer silently truncates long bodies.
- profilePath is returned only when a profile was actually dumped.

## Verification

- 21 external utility cases pass, including shell argument inspection, retention/counters, profiler failures/nesting and Expo controls (Expo fix is separate).
- Docs static build, TypeScript, ESLint and package builds pass on combined candidate.

Fixes #191. Fixes #192. Fixes #193.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
