### PR TITLE
fix: generate valid idempotent Android Expo bootstrap code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig([
     ignores: [
       '**/node_modules/**',
       '**/lib/**',
+      '**/expo/plugins/dist/**',
       '**/thirdparty/**',
       '**/nitrogen/**',
       '**/build/**',

--- a/packages/react-native-nitro-fetch/expo/plugins/src/withAndroid.ts
+++ b/packages/react-native-nitro-fetch/expo/plugins/src/withAndroid.ts
@@ -1,31 +1,34 @@
-import { withMainApplication } from '@expo/config-plugins';
+import { withMainApplication, type ConfigPlugin } from '@expo/config-plugins';
 
-const withAndroidAutoPrefetch = (config: any) => {
-  return withMainApplication(config, (config) => {
-    let content = config.modResults.contents;
+const withAndroidAutoPrefetch: ConfigPlugin = (config) => {
+  return withMainApplication(config, (mod) => {
+    let content = mod.modResults.contents;
+    const isJava = mod.modResults.language === 'java';
 
     // Add import for AutoPrefetcher
     if (
       !content.includes('import com.margelo.nitro.nitrofetch.AutoPrefetcher')
     ) {
       content = content.replace(
-        /import android.app.Application/g,
-        `import android.app.Application
-import com.margelo.nitro.nitrofetch.AutoPrefetcher`
+        /^(\s*package\s+[^\r\n]+)$/m,
+        `$1\n\nimport com.margelo.nitro.nitrofetch.AutoPrefetcher${
+          isJava ? ';' : ''
+        }`
       );
     }
 
     // Add prefetchOnStart call in onCreate before loadReactNative
-    if (!content.includes('AutoPrefetcher.prefetchOnStart')) {
+    if (!/AutoPrefetcher(?:\.INSTANCE)?\.prefetchOnStart/.test(content)) {
       content = content.replace(
-        /super\.onCreate\(\)/,
-        `super.onCreate()
-    try { AutoPrefetcher.prefetchOnStart(this) } catch (_: Throwable) {}`
+        /super\.onCreate\(\);?/,
+        isJava
+          ? 'super.onCreate();\n    try { AutoPrefetcher.INSTANCE.prefetchOnStart(this); } catch (Throwable ignored) {}'
+          : 'super.onCreate()\n    try { AutoPrefetcher.prefetchOnStart(this) } catch (_: Throwable) {}'
       );
     }
 
-    config.modResults.contents = content;
-    return config;
+    mod.modResults.contents = content;
+    return mod;
   });
 };
 


### PR DESCRIPTION
## Fixes

- Insert imports after the package declaration and generate language-correct try/catch syntax.
- Use the Kotlin object INSTANCE entrypoint from Java and recognize both Java/Kotlin calls on repeated runs.
- Use the actual config-plugin callback parameter and type.

## Compatibility / breaking changes

- No public API or behavior break intended.

## Verification

- Generated Java and Kotlin Application fixtures compile against the actual built AutoPrefetcher class; both remain unchanged on a second plugin pass.
- Expo plugin TypeScript check and package lint pass.

Fixes #194.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

### Generated plugin output

The root lint configuration now ignores only expo/plugins/dist (already generated and Git-ignored), so compiling the plugin does not create 27 formatting errors in emitted code. Plugin source remains linted. Root lint passes before and after the plugin build. Fixes #220.

### Consumer follow-up verification

The combined fixes are backported to an immutable 1.6.1 artifact. Both consuming app Android Debug variants, both iOS Debug Simulator variants, four production Metro bundles, 13 web targets, four browser-extension builds, lint and immutable installation pass. All 274 installed non-metadata files match the artifact. This is build verification, not a physical-device authentication/upload certification.
