### PR TITLE
fix: point the fetch podspec at its tagged source repository

### DIFF
--- a/packages/react-native-nitro-fetch/NitroFetch.podspec
+++ b/packages/react-native-nitro-fetch/NitroFetch.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported }
-  s.source       = { :git => "http://google.com.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-nitro-fetch.git", :tag => "v#{s.version}" }
 
 
   s.source_files = [


### PR DESCRIPTION
## Fixes

- Replace the placeholder HTTP Google repository with the actual HTTPS repository and v-prefixed package tag.

## Compatibility / breaking changes

- No public API or behavior break intended.

## Verification

- Verified v1.6.1/v1.6.3 source tags; CocoaPods install and iOS example builds pass.

Fixes #195.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
