### PR TITLE
fix: atomically initialize the shared native storage master

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -52,6 +52,7 @@ object AutoPrefetcher {
     val appContext = context.applicationContext
     executor.execute {
       try {
+        NitroFetchSecureAtRest.initialize(appContext)
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         // Entries embed request headers (may hold credentials) — encrypted-at-rest; legacy plaintext migrates on read.
         val raw = NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_QUEUE) ?: ""
@@ -87,6 +88,7 @@ object AutoPrefetcher {
     if (initialized) return
     initialized = true
     try {
+      NitroFetchSecureAtRest.initialize(app)
       val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
       val raw = NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_QUEUE) ?: ""
       if (raw.isEmpty()) return

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNativeStorage.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNativeStorage.kt
@@ -7,6 +7,8 @@ import android.security.keystore.KeyProperties
 import android.util.Base64
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.NitroModules
+import java.io.File
+import java.io.RandomAccessFile
 import java.security.KeyStore
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -24,28 +26,42 @@ internal object NitroFetchSecureAtRest {
   private const val GCM_IV_LENGTH = 12
   private const val GCM_TAG_BITS = 128
   const val ENC_PREFIX = "nfc1:"
+  @Volatile private var keyLockFile: File? = null
+
+  fun initialize(context: Context) {
+    keyLockFile = File(context.applicationContext.noBackupFilesDir, "$KEYSTORE_ALIAS.lock")
+  }
 
   private fun keyStore(): KeyStore =
     KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
 
-  private fun getOrCreateSecretKey(): javax.crypto.SecretKey {
+  // The optional WebSocket package uses this same interned alias monitor.
+  // The file lock also covers secondary application processes.
+  private fun getOrCreateSecretKey(): javax.crypto.SecretKey = synchronized(KEYSTORE_ALIAS.intern()) {
     val ks = keyStore()
-    if (ks.containsAlias(KEYSTORE_ALIAS)) {
-      return (ks.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry).secretKey
+    (ks.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?)?.let {
+      return@synchronized it.secretKey
     }
-    val keyGenerator =
-      KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
-    val spec =
-      KeyGenParameterSpec.Builder(
-        KEYSTORE_ALIAS,
-        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-      )
-        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-        .setKeySize(256)
-        .build()
-    keyGenerator.init(spec)
-    return keyGenerator.generateKey()
+    RandomAccessFile(checkNotNull(keyLockFile), "rw").use { file ->
+      file.channel.lock().use {
+        // Another process may have installed the master while we waited.
+        (keyStore().getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?)?.let {
+          return@synchronized it.secretKey
+        }
+        val keyGenerator =
+          KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+          KEYSTORE_ALIAS,
+          KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+          .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+          .setKeySize(256)
+          .build()
+        keyGenerator.init(spec)
+        keyGenerator.generateKey()
+      }
+    }
   }
 
   private fun encrypt(plaintext: String): String {
@@ -117,6 +133,7 @@ class HybridNativeStorage : HybridNativeStorageSpec() {
       val context =
         NitroModules.applicationContext
           ?: throw Error("Cannot get Android Context - No Context available!")
+      NitroFetchSecureAtRest.initialize(context)
       context.getSharedPreferences(NitroFetchSecureAtRest.PREFS_NAME, Context.MODE_PRIVATE)
     }
 

--- a/packages/react-native-nitro-fetch/ios/HybridNativeStorage.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNativeStorage.swift
@@ -14,8 +14,8 @@ internal enum NitroFetchSecureAtRest {
   private static let keychainAccount = "master"
 
   private static func loadOrCreateSymmetricKey() throws -> SymmetricKey {
-    if let data = try loadKeyData(), data.count == 32 {
-      return SymmetricKey(data: data)
+    if let data = try loadKeyData() {
+      return try validatedKey(data)
     }
     var bytes = [UInt8](repeating: 0, count: 32)
     let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
@@ -23,7 +23,13 @@ internal enum NitroFetchSecureAtRest {
       throw NSError(domain: "NitroFetchSecure", code: Int(status), userInfo: nil)
     }
     let data = Data(bytes)
-    try saveKeyData(data)
+    return try validatedKey(saveKeyData(data))
+  }
+
+  private static func validatedKey(_ data: Data) throws -> SymmetricKey {
+    guard data.count == 32 else {
+      throw NSError(domain: "NitroFetchSecure", code: Int(errSecDecode), userInfo: nil)
+    }
     return SymmetricKey(data: data)
   }
 
@@ -45,13 +51,7 @@ internal enum NitroFetchSecureAtRest {
     return d
   }
 
-  private static func saveKeyData(_ data: Data) throws {
-    let deleteQuery: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: keychainService,
-      kSecAttrAccount as String: keychainAccount,
-    ]
-    SecItemDelete(deleteQuery as CFDictionary)
+  private static func saveKeyData(_ data: Data) throws -> Data {
     let add: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: keychainService,
@@ -60,9 +60,15 @@ internal enum NitroFetchSecureAtRest {
       kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
     ]
     let status = SecItemAdd(add as CFDictionary, nil)
+    // Fetch and WebSocket startup share this master. Never replace a key
+    // another caller may already have used to encrypt persisted data.
+    if status == errSecDuplicateItem, let existing = try loadKeyData() {
+      return existing
+    }
     guard status == errSecSuccess else {
       throw NSError(domain: "NitroFetchSecure", code: Int(status), userInfo: nil)
     }
+    return data
   }
 
   private static func encrypt(_ plain: String) throws -> String {
@@ -78,7 +84,10 @@ internal enum NitroFetchSecureAtRest {
     guard let raw = Data(base64Encoded: b64) else {
       throw NSError(domain: "NitroFetchSecure", code: -2, userInfo: nil)
     }
-    let key = try loadOrCreateSymmetricKey()
+    guard let keyData = try loadKeyData() else {
+      throw NSError(domain: "NitroFetchSecure", code: Int(errSecItemNotFound), userInfo: nil)
+    }
+    let key = try validatedKey(keyData)
     let box = try AES.GCM.SealedBox(combined: raw)
     let data = try AES.GCM.open(box, using: key)
     guard let s = String(data: data, encoding: .utf8) else {

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -10,6 +10,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
+import java.io.File
+import java.io.RandomAccessFile
 import java.security.KeyStore
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -27,28 +29,40 @@ private object NitroWSSecureAtRest {
   private const val GCM_IV_LENGTH = 12
   private const val GCM_TAG_BITS = 128
   const val ENC_PREFIX = "nfc1:"
+  @Volatile private var keyLockFile: File? = null
+
+  fun initialize(context: Context) {
+    keyLockFile = File(context.applicationContext.noBackupFilesDir, "$KEYSTORE_ALIAS.lock")
+  }
 
   private fun keyStore(): KeyStore =
     KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
 
-  private fun getOrCreateSecretKey(): javax.crypto.SecretKey {
+  // Match nitro-fetch's monitor without requiring that optional package.
+  private fun getOrCreateSecretKey(): javax.crypto.SecretKey = synchronized(KEYSTORE_ALIAS.intern()) {
     val ks = keyStore()
-    if (ks.containsAlias(KEYSTORE_ALIAS)) {
-      return (ks.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry).secretKey
+    (ks.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?)?.let {
+      return@synchronized it.secretKey
     }
-    val keyGenerator =
-      KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
-    val spec =
-      KeyGenParameterSpec.Builder(
-        KEYSTORE_ALIAS,
-        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-      )
-        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-        .setKeySize(256)
-        .build()
-    keyGenerator.init(spec)
-    return keyGenerator.generateKey()
+    RandomAccessFile(checkNotNull(keyLockFile), "rw").use { file ->
+      file.channel.lock().use {
+        (keyStore().getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?)?.let {
+          return@synchronized it.secretKey
+        }
+        val keyGenerator =
+          KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+          KEYSTORE_ALIAS,
+          KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+          .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+          .setKeySize(256)
+          .build()
+        keyGenerator.init(spec)
+        keyGenerator.generateKey()
+      }
+    }
   }
 
   private fun encrypt(plaintext: String): String {
@@ -132,6 +146,7 @@ object NitroWebSocketAutoPrewarmer {
     if (initialized) return
     initialized = true
     try {
+      NitroWSSecureAtRest.initialize(app)
       val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
       val raw = prefs.getString(KEY_QUEUE, null) ?: return
       val arr = JSONArray(raw)

--- a/packages/react-native-nitro-websockets/ios/NitroWSSecureAtRest.swift
+++ b/packages/react-native-nitro-websockets/ios/NitroWSSecureAtRest.swift
@@ -13,8 +13,8 @@ enum NitroWSSecureAtRest {
   private static let keychainAccount = "master"
 
   private static func loadOrCreateSymmetricKey() throws -> SymmetricKey {
-    if let data = try? loadKeyData(), data.count == 32 {
-      return SymmetricKey(data: data)
+    if let data = try loadKeyData() {
+      return try validatedKey(data)
     }
     var bytes = [UInt8](repeating: 0, count: 32)
     let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
@@ -22,11 +22,17 @@ enum NitroWSSecureAtRest {
       throw NSError(domain: "NitroWSSecure", code: Int(status), userInfo: nil)
     }
     let data = Data(bytes)
-    try saveKeyData(data)
+    return try validatedKey(saveKeyData(data))
+  }
+
+  private static func validatedKey(_ data: Data) throws -> SymmetricKey {
+    guard data.count == 32 else {
+      throw NSError(domain: "NitroWSSecure", code: Int(errSecDecode), userInfo: nil)
+    }
     return SymmetricKey(data: data)
   }
 
-  private static func loadKeyData() throws -> Data {
+  private static func loadKeyData() throws -> Data? {
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: keychainService,
@@ -36,19 +42,14 @@ enum NitroWSSecureAtRest {
     ]
     var out: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &out)
+    if status == errSecItemNotFound { return nil }
     guard status == errSecSuccess, let d = out as? Data else {
       throw NSError(domain: "NitroWSSecure", code: Int(status), userInfo: nil)
     }
     return d
   }
 
-  private static func saveKeyData(_ data: Data) throws {
-    let deleteQuery: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: keychainService,
-      kSecAttrAccount as String: keychainAccount,
-    ]
-    SecItemDelete(deleteQuery as CFDictionary)
+  private static func saveKeyData(_ data: Data) throws -> Data {
     let add: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: keychainService,
@@ -57,9 +58,15 @@ enum NitroWSSecureAtRest {
       kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
     ]
     let status = SecItemAdd(add as CFDictionary, nil)
+    // This master is also used by nitro-fetch; recover the winning insertion
+    // without replacing key material used by another caller.
+    if status == errSecDuplicateItem, let existing = try loadKeyData() {
+      return existing
+    }
     guard status == errSecSuccess else {
       throw NSError(domain: "NitroWSSecure", code: Int(status), userInfo: nil)
     }
+    return data
   }
 
   private static func encrypt(_ plain: String) throws -> String {
@@ -75,7 +82,10 @@ enum NitroWSSecureAtRest {
     guard let raw = Data(base64Encoded: b64) else {
       throw NSError(domain: "NitroWSSecure", code: -2, userInfo: nil)
     }
-    let key = try loadOrCreateSymmetricKey()
+    guard let keyData = try loadKeyData() else {
+      throw NSError(domain: "NitroWSSecure", code: Int(errSecItemNotFound), userInfo: nil)
+    }
+    let key = try validatedKey(keyData)
     let box = try AES.GCM.SealedBox(combined: raw)
     let data = try AES.GCM.open(box, using: key)
     guard let s = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
## Fixes

- Preserve one shared AES-GCM master across Fetch and optional WebSocket startup.
- Use add-only Keychain insertion and reload the winning duplicate; reject malformed/existing-key read failures without replacing the master.
- Use a shared interned monitor and OS file lock for Android first-key creation, recheck inside the file lock, and leave ordinary existing-key reads off the file-lock path.

## Compatibility / breaking changes

- No ciphertext-format, alias, key size, accessibility, queue schema or automatic key-rotation change. Both optional packages need the fix when used together; an old writer is not made safe by upgrading only its peer.
- The documented Fetch plaintext fallback when secure storage is unavailable remains unchanged. WebSocket encryption failure does not gain a plaintext fallback. Existing corrupted data cannot be recovered by this fix.

## Verification

- Fresh read-only boundary investigation and independent candidate review completed; the review identified and prompted the cross-process lock.
- 13 Swift/CryptoKit cases pass against mock Keychain/Defaults, including 20 forced cross-package races, malformed keys, transient errors, legacy migration and fallback controls.
- Seven compiled JVM checks plus a two-process OS-file-lock check pass with a mock Keystore provider and real AES-GCM; original race reproductions fail on baseline.
- Real Android/iOS example builds pass. Physical-device Keystore/Keychain execution and restore scenarios remain unverified; mocks are not claimed as device verification.

Fixes #198.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
