### PR TITLE
fix: keep bootstrap logs and native trace labels metadata-only

### DIFF
--- a/docs-website/docs/inspection.md
+++ b/docs-website/docs/inspection.md
@@ -30,6 +30,8 @@ NetworkInspector.disable();
 
 Once enabled, **all `fetch()` calls** are automatically recorded. WebSocket tracking is also automatic if `react-native-nitro-websockets` is installed alongside `react-native-nitro-fetch`.
 
+The inspector and attached React Native DevTools intentionally expose request URLs, headers and captured bodies. Treat exported diagnostics as sensitive. Automatic bootstrap logs and native trace labels contain metadata rather than token values, URL paths, or WebSocket error strings; this does not redact the explicitly enabled inspector.
+
 ### Reading entries
 
 ```ts
@@ -249,9 +251,9 @@ Then rebuild your app. The env vars inject compile-time flags (`NITROFETCH_TRACI
 
 When `NitroFetch_enableTracing=true` (Android) or `NITROFETCH_TRACING=1` (iOS) is set:
 
-- **Android**: Each `fetch()` call emits an **async section** via `android.os.Trace.beginAsyncSection` / `endAsyncSection`. The label is `"NitroFetch <METHOD> <path>"` (e.g., `NitroFetch GET /api/users`). The section spans from request start to response completion (including success, failure, and cancellation).
+- **Android**: Each `fetch()` call emits an **async section** via `android.os.Trace.beginAsyncSection` / `endAsyncSection`. The label is `"NitroFetch <METHOD>"` (e.g., `NitroFetch GET`). The section spans from request start to response completion (including success, failure, and cancellation).
 
-- **iOS**: Each `fetch()` call emits an **`os_signpost` interval** under subsystem `com.margelo.nitrofetch`, category `network`, name `"NitroFetch"`. The begin event includes `"<METHOD> <path>"` and the end event includes `"status=<code> bytes=<count>"`.
+- **iOS**: Each `fetch()` call emits an **`os_signpost` interval** under subsystem `com.margelo.nitrofetch`, category `network`, name `"NitroFetch"`. The begin event includes `"<METHOD>"` and the end event includes `"status=<code> bytes=<count>"`.
 
 #### WebSocket
 
@@ -279,7 +281,7 @@ When `NitroFetchWebsockets_enableTracing=true` (Android) or `NITRO_WS_TRACING=1`
 
 7. Click **"Start recording"**, use your app (make fetch requests, open WebSocket connections), then click **"Stop"**.
 
-8. In the trace viewer, look for your app's process. HTTP traces appear as async slices labeled `NitroFetch GET /path`, `NitroFetch POST /path`, etc. WebSocket traces appear as sync slices labeled `NitroWS connect <url>`, `NitroWS established`, `NitroWS send text`, `NitroWS receive`, etc.
+8. In the trace viewer, look for your app's process. HTTP traces appear as async slices labeled `NitroFetch GET`, `NitroFetch POST`, etc. WebSocket traces appear as sync slices labeled `NitroWS connect`, `NitroWS established`, `NitroWS send text`, `NitroWS receive`, etc.
 
 #### Option 2: Command-line with config file
 
@@ -335,9 +337,9 @@ Open the resulting `.perfetto-trace` file at [ui.perfetto.dev](https://ui.perfet
    | `com.margelo.nitrofetch` | `network` | HTTP fetch requests |
    | `com.margelo.nitro.websockets` | `NitroWS` | WebSocket lifecycle |
 
-   - **HTTP fetch**: Appears as **intervals** (begin/end pair) under name `"NitroFetch"`. The begin annotation shows the method and path (e.g., `GET /api/users`), the end annotation shows `status=200 bytes=1234`.
-   - **WebSocket connect**: Appears as an **interval** from `connect` (begin, annotated with the URL) to `connected` (end). This measures the handshake duration.
-   - **WebSocket send/receive/close/error**: Appear as **point events** under name `"NitroWS"` with details like `send text 42 bytes`, `receive text`, `close code=1000 clean=1`, `error <message>`.
+   - **HTTP fetch**: Appears as **intervals** (begin/end pair) under name `"NitroFetch"`. The begin annotation shows the method (e.g., `GET`), the end annotation shows `status=200 bytes=1234`.
+   - **WebSocket connect**: Appears as an **interval** from `connect` to `connected`. This measures the handshake duration without recording the URL.
+   - **WebSocket send/receive/close/error**: Appear as **point events** under name `"NitroWS"` with details like `send text 42 bytes`, `receive text`, `close code=1000 clean=1`, `error`.
 
 ### Trace events reference
 
@@ -345,8 +347,8 @@ Open the resulting `.perfetto-trace` file at [ui.perfetto.dev](https://ui.perfet
 
 | Event | Android | iOS |
 |-------|---------|-----|
-| Request start | `Trace.beginAsyncSection("NitroFetch GET /path", cookie)` | `os_signpost(.begin, "NitroFetch", "GET /path")` |
-| Request end (success) | `Trace.endAsyncSection("NitroFetch GET /path", cookie)` | `os_signpost(.end, "NitroFetch", "status=200 bytes=N")` |
+| Request start | `Trace.beginAsyncSection("NitroFetch GET", cookie)` | `os_signpost(.begin, "NitroFetch", "GET")` |
+| Request end (success) | `Trace.endAsyncSection("NitroFetch GET", cookie)` | `os_signpost(.end, "NitroFetch", "status=200 bytes=N")` |
 | Request end (failure) | `Trace.endAsyncSection(...)` | `os_signpost(.end, ...)` |
 | Request end (cancelled) | `Trace.endAsyncSection(...)` | `os_signpost(.end, ...)` |
 
@@ -354,13 +356,13 @@ Open the resulting `.perfetto-trace` file at [ui.perfetto.dev](https://ui.perfet
 
 | Event | Android (`ATrace`) | iOS (`os_signpost`) |
 |-------|-------------------|---------------------|
-| Connect start | `ATrace_beginSection("NitroWS connect wss://...")` | interval begin: `"NitroWS"` with URL |
+| Connect start | `ATrace_beginSection("NitroWS connect")` | interval begin: `"NitroWS"` `"connect"` |
 | Connected | `ATrace_beginSection("NitroWS established")` | interval end: `"NitroWS"` `"connected"` |
 | Send text | `ATrace_beginSection("NitroWS send text")` | event: `"send text <N> bytes"` |
 | Send binary | `ATrace_beginSection("NitroWS send binary")` | event: `"send binary <N> bytes"` |
 | Receive | `ATrace_beginSection("NitroWS receive")` | event: `"receive text"` or `"receive binary"` |
 | Close | `ATrace_beginSection("NitroWS close")` | event: `"close code=<N> clean=<0\|1>"` |
-| Error | `ATrace_beginSection("NitroWS error")` | event: `"error <message>"` |
+| Error | `ATrace_beginSection("NitroWS error")` | event: `"error"` |
 
 :::note
 On Android, WebSocket events use synchronous `ATrace_beginSection` / `ATrace_endSection` pairs (not async sections) because `ATrace_beginAsyncSection` requires API 29+ while the library supports API 24+. HTTP fetch uses the Java `android.os.Trace.beginAsyncSection` API which is available on all supported API levels.

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -97,8 +97,7 @@ object AutoPrefetcher {
       if (!refreshRaw.isNullOrEmpty()) {
         val refreshConfig = JSONObject(refreshRaw)
         val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
-        val refreshURL = refreshConfig.optString("url", "(unknown)")
-        NitroLogger.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
+        NitroLogger.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint")
 
         val refreshed = callTokenRefreshSync(refreshConfig)
 
@@ -108,12 +107,11 @@ object AutoPrefetcher {
             "[TokenRefresh] ✅ Success — got ${refreshed.headers.size} header(s), " +
               "${refreshed.bodyFields.size} body field(s), ${refreshed.formFields.size} form field(s)"
           )
-          logTokens(refreshed)
           // Cache fresh tokens for useStoredHeaders fallback on next cold start
           NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
           refreshed
         } else {
-          NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
+          NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed")
           if (onFailure == "skip") {
             NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
             return
@@ -145,8 +143,7 @@ object AutoPrefetcher {
       val url = o.optStringOrNull("url") ?: continue
       val prefetchKey = o.optStringOrNull("prefetchKey") ?: continue
 
-      NitroLogger.d("NitroFetch", "[TokenRefresh] Prefetching $url")
-      logTokens(tokens)
+      NitroLogger.d("NitroFetch", "[TokenRefresh] Starting prefetch")
 
       val req = buildNitroRequestFromEntry(o, tokens)
 
@@ -292,27 +289,6 @@ object AutoPrefetcher {
   }
 
   // MARK: - Token refresh (synchronous, runs on background thread)
-
-  private fun logTokens(tokens: TokenRefreshResult) {
-    if (tokens.headers.isNotEmpty()) {
-      NitroLogger.d("NitroFetch", "[TokenRefresh]   headers:")
-      tokens.headers.forEach { (k, v) ->
-        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
-      }
-    }
-    if (tokens.bodyFields.isNotEmpty()) {
-      NitroLogger.d("NitroFetch", "[TokenRefresh]   body fields:")
-      tokens.bodyFields.forEach { (k, v) ->
-        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
-      }
-    }
-    if (tokens.formFields.isNotEmpty()) {
-      NitroLogger.d("NitroFetch", "[TokenRefresh]   form fields:")
-      tokens.formFields.forEach { (k, v) ->
-        NitroLogger.d("NitroFetch", "[TokenRefresh]     $k: $v")
-      }
-    }
-  }
 
   private data class TokenRefreshResult(
     val headers: Map<String, String>,

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -111,7 +111,7 @@ object AutoPrefetcher {
           NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
           refreshed
         } else {
-          NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed")
+          NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
           if (onFailure == "skip") {
             NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
             return

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -110,7 +110,7 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
       val shouldFollowRedirects = req.followRedirects ?: true
       val omitCredentials = req.credentials == NitroRequestCredentials.OMIT
       val traceLabel = if (BuildConfig.NITRO_FETCH_TRACING) {
-        "NitroFetch ${req.method?.name ?: "GET"} ${Uri.parse(url).path ?: url}"
+        "NitroFetch ${req.method?.name ?: "GET"}"
       } else ""
       val traceCookie = if (BuildConfig.NITRO_FETCH_TRACING) url.hashCode() else 0
       if (BuildConfig.NITRO_FETCH_TRACING) {

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -188,9 +188,8 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
     #if NITROFETCH_TRACING
     let signpostID = OSSignpostID(log: fetchLog)
     let traceMethod = req.method?.stringValue ?? "GET"
-    let tracePath = URL(string: req.url)?.path ?? req.url
     os_signpost(.begin, log: fetchLog, name: "NitroFetch", signpostID: signpostID,
-                "%{public}s %{public}s", traceMethod, tracePath)
+                "%{public}s", traceMethod)
     #endif
 
     // DevTools/CDP reporting is gated on `#if DEBUG` so the entire block is

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -160,7 +160,7 @@ public final class NitroAutoPrefetcher: NSObject {
           }
           tokens = refreshed
         } else {
-          NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed")
+          NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed — onFailure: \(onFailure)")
           if onFailure == "skip" {
             NitroLogger.log("[NitroFetch][TokenRefresh] Skipping all prefetches")
             return

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -150,19 +150,17 @@ public final class NitroAutoPrefetcher: NSObject {
          let refreshData = refreshRaw.data(using: .utf8),
          let refreshObj = try? JSONSerialization.jsonObject(with: refreshData) as? [String: Any] {
         let onFailure = refreshObj["onFailure"] as? String ?? "useStoredHeaders"
-        let refreshURL = refreshObj["url"] as? String ?? "(unknown)"
-        NitroLogger.log("[NitroFetch][TokenRefresh] Calling refresh endpoint: \(refreshURL)")
+        NitroLogger.log("[NitroFetch][TokenRefresh] Calling refresh endpoint")
         let refreshed = try? await callTokenRefresh(config: refreshObj)
         if let refreshed = refreshed {
           NitroLogger.log("[NitroFetch][TokenRefresh] ✅ Success — got \(refreshed.headers.count) header(s), \(refreshed.bodyFields.count) body field(s), \(refreshed.formFields.count) form field(s)")
-          logTokens(refreshed)
           // Cache fresh tokens for useStoredHeaders fallback on next cold start
           if let cacheStr = serializeCache(refreshed) {
             NitroFetchSecureAtRest.setEncrypted(cacheStr, forKey: tokenCacheKey, defaults: userDefaults)
           }
           tokens = refreshed
         } else {
-          NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed — onFailure: \(onFailure)")
+          NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed")
           if onFailure == "skip" {
             NitroLogger.log("[NitroFetch][TokenRefresh] Skipping all prefetches")
             return
@@ -187,8 +185,7 @@ public final class NitroAutoPrefetcher: NSObject {
       guard let url = obj["url"] as? String, !url.isEmpty else { continue }
       guard let prefetchKey = obj["prefetchKey"] as? String, !prefetchKey.isEmpty else { continue }
 
-      NitroLogger.log("[NitroFetch][TokenRefresh] Prefetching \(url)")
-      logTokens(tokens)
+      NitroLogger.log("[NitroFetch][TokenRefresh] Starting prefetch")
 
       let req = buildNitroRequest(from: obj, tokens: tokens)
       Task {
@@ -286,21 +283,6 @@ public final class NitroAutoPrefetcher: NSObject {
   }
 
   // MARK: - Token refresh
-
-  private static func logTokens(_ tokens: TokenRefreshResult) {
-    if !tokens.headers.isEmpty {
-      NitroLogger.log("[NitroFetch][TokenRefresh]   headers:")
-      for (k, v) in tokens.headers { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
-    }
-    if !tokens.bodyFields.isEmpty {
-      NitroLogger.log("[NitroFetch][TokenRefresh]   body fields:")
-      for (k, v) in tokens.bodyFields { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
-    }
-    if !tokens.formFields.isEmpty {
-      NitroLogger.log("[NitroFetch][TokenRefresh]   form fields:")
-      for (k, v) in tokens.formFields { NitroLogger.log("[NitroFetch][TokenRefresh]     \(k): \(v)") }
-    }
-  }
 
   struct TokenRefreshResult {
     var headers: [String: String]

--- a/packages/react-native-nitro-websockets/android/src/main/cpp/WebSocketConnection.cpp
+++ b/packages/react-native-nitro-websockets/android/src/main/cpp/WebSocketConnection.cpp
@@ -142,7 +142,7 @@ void WebSocketConnection::connect(
   _negotiatedProtocol.clear();
 
 #if defined(NITRO_WS_TRACING)
-  ATrace_beginSection(("NitroWS connect " + url).c_str());
+  ATrace_beginSection("NitroWS connect");
 #endif
 
   ParsedUrl parsed;

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -157,7 +157,7 @@ object NitroWebSocketAutoPrewarmer {
               NitroWSSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, cacheJson.toString())
               refreshed
             } else {
-              NitroLogger.d("NitroWS", "[TokenRefresh] ❌ Refresh failed")
+              NitroLogger.d("NitroWS", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
               if (onFailure == "skip") {
                 NitroLogger.d("NitroWS", "[TokenRefresh] Skipping all prewarms")
                 return@Thread

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -145,21 +145,19 @@ object NitroWebSocketAutoPrewarmer {
           try {
             val refreshConfig = JSONObject(refreshRaw)
             val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
-            val refreshURL = refreshConfig.optString("url", "(unknown)")
-            NitroLogger.d("NitroWS", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
+            NitroLogger.d("NitroWS", "[TokenRefresh] Calling refresh endpoint")
 
             val refreshed = callTokenRefreshSync(refreshConfig)
 
             val tokenHeaders: Map<String, String> = if (refreshed != null) {
               NitroLogger.d("NitroWS", "[TokenRefresh] ✅ Success — got ${refreshed.size} header(s)")
-              refreshed.forEach { (k, v) -> NitroLogger.d("NitroWS", "[TokenRefresh]   $k: $v") }
               // Cache fresh token headers for useStoredHeaders fallback on next cold start
               val cacheJson = JSONObject()
               refreshed.forEach { (k, v) -> cacheJson.put(k, v) }
               NitroWSSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, cacheJson.toString())
               refreshed
             } else {
-              NitroLogger.d("NitroWS", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
+              NitroLogger.d("NitroWS", "[TokenRefresh] ❌ Refresh failed")
               if (onFailure == "skip") {
                 NitroLogger.d("NitroWS", "[TokenRefresh] Skipping all prewarms")
                 return@Thread
@@ -197,7 +195,6 @@ object NitroWebSocketAutoPrewarmer {
     for (i in 0 until arr.length()) {
       val obj = arr.optJSONObject(i) ?: continue
       val url = obj.optStringOrNull("url") ?: continue
-      NitroLogger.d("NitroWS", "Pre-warming $url")
 
       val protocols = mutableListOf<String>()
       val protocolsArr = obj.optJSONArray("protocols")
@@ -217,8 +214,7 @@ object NitroWebSocketAutoPrewarmer {
       }
       tokenHeaders.forEach { (k, v) -> merged[k] = v }
 
-      NitroLogger.d("NitroWS", "[TokenRefresh] Pre-warming $url with ${merged.size} header(s)")
-      merged.forEach { (k, v) -> NitroLogger.d("NitroWS", "[TokenRefresh]   $k: $v") }
+      NitroLogger.d("NitroWS", "[TokenRefresh] Pre-warming with ${merged.size} header(s)")
       NitroWebSocketPrewarmer.preWarm(url, protocols, merged)
     }
   }

--- a/packages/react-native-nitro-websockets/ios/NWWebSocketConnection.mm
+++ b/packages/react-native-nitro-websockets/ios/NWWebSocketConnection.mm
@@ -107,8 +107,7 @@ void NWWebSocketConnection::connect(
 #if defined(NITRO_WS_TRACING)
   os_signpost_id_t spid = os_signpost_id_generate(nitroWsLog());
   _signpostId = spid;
-  os_signpost_interval_begin(nitroWsLog(), spid, "NitroWS",
-                              "%{public}s", url.c_str());
+  os_signpost_interval_begin(nitroWsLog(), spid, "NitroWS", "connect");
 #endif
   _closeFired = false;
   _openFired = false;
@@ -514,7 +513,7 @@ void NWWebSocketConnection::fireError(const std::string& msg) {
 #if defined(NITRO_WS_TRACING)
   os_signpost_event_emit(nitroWsLog(),
     static_cast<os_signpost_id_t>(_signpostId),
-    "NitroWS", "error %{public}s", msg.c_str());
+    "NitroWS", "error");
 #endif
 
   OnError cb;

--- a/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
+++ b/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
@@ -200,10 +200,7 @@ static void NitroWSRunPrewarmsWithTokenHeaders(NSArray *arr,
       headers[[k UTF8String]] = [v UTF8String];
     }];
 
-    NitroWSLog(@"[NitroWS] Pre-warming %@ with %zu header(s)", url, headers.size());
-    for (auto &kv : headers) {
-      NitroWSLog(@"[NitroWS]   %s: %s", kv.first.c_str(), kv.second.c_str());
-    }
+    NitroWSLog(@"[NitroWS] Pre-warming with %zu header(s)", headers.size());
     margelo::nitro::nitrofetchwebsockets::WebSocketPrewarmer::instance()
       .preConnect(urlStr, protocols, headers);
   }
@@ -247,15 +244,11 @@ static void NitroWSRunAutoPrewarm() {
           NSString *onFailure = refreshConfig[@"onFailure"];
           if (![onFailure isKindOfClass:[NSString class]]) onFailure = @"useStoredHeaders";
 
-          NSString *refreshURL = refreshConfig[@"url"];
-          NitroWSLog(@"[NitroWS][TokenRefresh] Calling refresh endpoint: %@", refreshURL);
+          NitroWSLog(@"[NitroWS][TokenRefresh] Calling refresh endpoint");
 
           NSDictionary *refreshed = NitroWSCallTokenRefreshSync(refreshConfig);
           if (refreshed) {
             NitroWSLog(@"[NitroWS][TokenRefresh] ✅ Success — got %lu header(s)", (unsigned long)refreshed.count);
-            [refreshed enumerateKeysAndObjectsUsingBlock:^(NSString *k, NSString *v, BOOL *stop) {
-              NitroWSLog(@"[NitroWS][TokenRefresh]   %@: %@", k, v);
-            }];
             // Cache fresh token headers
             NSData *cacheData = [NSJSONSerialization dataWithJSONObject:refreshed options:0 error:nil];
             if (cacheData) {
@@ -266,7 +259,7 @@ static void NitroWSRunAutoPrewarm() {
             }
             tokenHeaders = refreshed;
           } else {
-            NitroWSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed — onFailure: %@", onFailure);
+            NitroWSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed");
             if ([onFailure isEqualToString:@"skip"]) {
               NitroWSLog(@"[NitroWS][TokenRefresh] Skipping all prewarms");
               return;

--- a/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
+++ b/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
@@ -259,7 +259,7 @@ static void NitroWSRunAutoPrewarm() {
             }
             tokenHeaders = refreshed;
           } else {
-            NitroWSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed");
+            NitroWSLog(@"[NitroWS][TokenRefresh] ❌ Refresh failed — onFailure: %@", onFailure);
             if ([onFailure isEqualToString:@"skip"]) {
               NitroWSLog(@"[NitroWS][TokenRefresh] Skipping all prewarms");
               return;


### PR DESCRIPTION
## Fixes

- Remove token/header/body/form values and request URLs from automatic Fetch/WebSocket bootstrap logs.
- Remove HTTP paths, WebSocket URLs and arbitrary WebSocket error strings from opt-in native trace labels, preserving timing/status/byte-count instrumentation.
- Document the intentional sensitive-data boundary of explicitly enabled NetworkInspector and attached DevTools.

## Compatibility / breaking changes

- Logs/traces no longer identify requests by URL/path or print credentials. HTTP method, status, counts and timing remain.
- Normal logging is enabled in debug builds; release logging/tracing require explicit opt-in. This is not a claim that default release builds exposed these values.
- NetworkInspector and attached DevTools intentionally retain their diagnostic capture behavior and require care when exporting.

## Verification

- Synthetic canary execution across all automatic Swift/Kotlin/ObjC bootstrap log expressions changes baseline leakage to no leakage; no real credentials were used.
- Android/iOS example builds pass with native tracing explicitly enabled. Fresh investigator/reviewer examined shared logging callers and bypass paths.
- No claim of a full device log-capture test or of redaction in the deliberately enabled inspectors.

Fixes #199. Fixes #205.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
