### PR TITLE
fix: close Android token-refresh connections on every exit

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -325,6 +325,7 @@ object AutoPrefetcher {
   }
 
   private fun callTokenRefreshSync(config: JSONObject): TokenRefreshResult? {
+    var connection: HttpURLConnection? = null
     return try {
       val urlStr = config.optStringOrNull("url") ?: return null
       val method = config.optString("method", "POST")
@@ -333,6 +334,7 @@ object AutoPrefetcher {
       val responseType = config.optString("responseType", "json")
 
       val conn = URL(urlStr).openConnection() as HttpURLConnection
+      connection = conn
       conn.requestMethod = method
       conn.connectTimeout = 10_000
       conn.readTimeout = 10_000
@@ -355,6 +357,7 @@ object AutoPrefetcher {
       val status = conn.responseCode
       if (status !in 200..299) {
         NitroLogger.d("NitroFetch", "[TokenRefresh] Refresh endpoint returned HTTP $status")
+        conn.errorStream?.close()
         return null
       }
 
@@ -365,6 +368,8 @@ object AutoPrefetcher {
       parseTokenResponse(responseBody, responseType, config)
     } catch (_: Throwable) {
       null
+    } finally {
+      connection?.disconnect()
     }
   }
 

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -226,6 +226,7 @@ object NitroWebSocketAutoPrewarmer {
   // MARK: - Token refresh (synchronous, runs on background thread)
 
   private fun callTokenRefreshSync(config: JSONObject): Map<String, String>? {
+    var connection: HttpURLConnection? = null
     return try {
       val urlStr = config.optStringOrNull("url") ?: return null
       val method = config.optString("method", "POST")
@@ -234,6 +235,7 @@ object NitroWebSocketAutoPrewarmer {
       val responseType = config.optString("responseType", "json")
 
       val conn = URL(urlStr).openConnection() as HttpURLConnection
+      connection = conn
       conn.requestMethod = method
       conn.connectTimeout = 10_000
       conn.readTimeout = 10_000
@@ -249,13 +251,18 @@ object NitroWebSocketAutoPrewarmer {
       }
 
       val status = conn.responseCode
-      if (status !in 200..299) return null
+      if (status !in 200..299) {
+        conn.errorStream?.close()
+        return null
+      }
 
       val responseBody = conn.inputStream.use { it.bufferedReader(Charsets.UTF_8).readText() }
 
       parseTokenResponse(responseBody, responseType, config)
     } catch (_: Throwable) {
       null
+    } finally {
+      connection?.disconnect()
     }
   }
 


### PR DESCRIPTION
## Fixes

- Disconnect both Fetch and optional WebSocket HttpURLConnections in finally blocks.
- Close non-2xx error streams and preserve existing success/failure fallback behavior.

## Compatibility / breaking changes

- No public API or behavior break intended.

## Verification

- Eight compiled Kotlin cases pass: both implementations on success, non-2xx, response-code failure and body-read failure. All eight fail their cleanup assertions on the baseline.
- Android example builds pass; synthetic connections isolate resource lifecycle without contacting real refresh endpoints.

Fixes #204.

Changes were reviewed against upstream 627c77e234ab73c81faf2836425c64dc511f07b8. No test/spec files were added or modified. Release/version selection is left to the maintainers.

## Consumer verification

All nine independent PR source overlays pass TypeScript. The combined fixes were backported to the existing 1.6.1 package without upgrading its dependency constraints. Both Android/iOS app variants, four production Metro bundles, 13 web builds, four extension builds and app lint pass. The installed artifact is immutable and its 269 non-metadata files match the build-verified candidate.
