### PR TITLE
fix: preserve native token mapping and header override semantics

### DIFF
--- a/docs-website/docs/token-refresh.md
+++ b/docs-website/docs/token-refresh.md
@@ -44,6 +44,8 @@ registerTokenRefresh({
 
 Use **`mappings`** to copy fields from the JSON body into header names. Dot paths are supported (e.g., `data.token`):
 
+Nested arrays use zero-based numeric segments, such as `tokens.0.value`. Missing or JSON-null values are omitted; booleans become `true`/`false`. Malformed JSON follows `onFailure` on both platforms instead of being cached as a successful empty refresh. Header merging is case-insensitive: a refreshed `authorization` replaces stored `Authorization`, and the internal prefetch key overrides all casing variants.
+
 ```ts
 mappings: [
   {
@@ -57,6 +59,8 @@ mappings: [
 ### Composite headers
 
 Use **`compositeHeaders`** to build a header from a template and multiple JSON paths:
+
+Native composite templates insert values literally in one pass, including text that looks like another placeholder. Configured paths with missing/null values become empty strings; placeholders not listed in `paths` remain unchanged. Placeholder names may include hyphens. Web cold-start APIs remain documented no-ops.
 
 ```ts
 compositeHeaders: [

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -226,10 +226,10 @@ object AutoPrefetcher {
     // Merge: static headers first, token headers override, then prefetchKey
     val mergedHeaders = mutableMapOf<String, String>()
     headersObj.keys().forEachRemaining { k ->
-      mergedHeaders[k] = headersObj.optString(k, "")
+      mergedHeaders[k.lowercase()] = headersObj.optString(k, "")
     }
-    tokens.headers.forEach { (k, v) -> mergedHeaders[k] = v }
-    mergedHeaders["prefetchKey"] = prefetchKey
+    tokens.headers.forEach { (k, v) -> mergedHeaders[k.lowercase()] = v }
+    mergedHeaders["prefetchkey"] = prefetchKey
     val headerObjs = mergedHeaders.map { (k, v) -> NitroHeader(k, v) }.toTypedArray()
 
     val methodStr = entry.optString("method", "").takeIf { it.isNotEmpty() }
@@ -389,9 +389,8 @@ object AutoPrefetcher {
     }
 
     // JSON
-    val json = try { JSONObject(body) } catch (_: Throwable) {
-      return TokenRefreshResult(headers, bodyFields, formFields)
-    }
+    // Let the caller apply onFailure instead of caching an empty success.
+    val json = JSONObject(body)
 
     collectMappings(json, config.optJSONArray("mappings"), "header", headers)
     collectMappings(json, config.optJSONArray("bodyMappings"), "bodyPath", bodyFields)
@@ -404,12 +403,7 @@ object AutoPrefetcher {
         val header = comp.optStringOrNull("header") ?: continue
         val template = comp.optStringOrNull("template") ?: continue
         val paths = comp.optJSONObject("paths") ?: continue
-        var built = template
-        paths.keys().forEachRemaining { ph ->
-          val val2 = getNestedField(json, paths.optString(ph, ""))
-          built = built.replace("{{$ph}}", val2 ?: "")
-        }
-        headers[header] = built
+        headers[header] = applyCompositeTemplate(template, paths, json)
       }
     }
 
@@ -438,11 +432,23 @@ object AutoPrefetcher {
     val parts = dotPath.split(".")
     var current: Any = obj
     for (part in parts) {
-      if (current !is JSONObject) return null
-      current = current.opt(part) ?: return null
+      current = when (val value = current) {
+        is JSONObject -> value.opt(part)
+        is JSONArray -> part.toIntOrNull()?.takeIf { it >= 0 && it.toString() == part }?.let { value.opt(it) }
+        else -> null
+      } ?: return null
     }
+    if (current === JSONObject.NULL) return null
     return current.toString()
   }
+
+  private val compositeTemplatePattern = Regex("\\{\\{([^{}]+)\\}\\}")
+
+  private fun applyCompositeTemplate(template: String, paths: JSONObject, json: JSONObject): String =
+    compositeTemplatePattern.replace(template) { match ->
+      val placeholder = match.groupValues[1]
+      if (paths.has(placeholder)) getNestedField(json, paths.optString(placeholder, "")) ?: "" else match.value
+    }
 
   private fun setNestedField(root: JSONObject, dotPath: String, value: String) {
     val parts = dotPath.split(".")

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreFoundation
 
 @objc(NitroAutoPrefetcher)
 public final class NitroAutoPrefetcher: NSObject {
@@ -244,9 +245,9 @@ public final class NitroAutoPrefetcher: NSObject {
 
     // Merge: static headers first, token headers override, then prefetchKey
     var mergedHeaders: [String: String] = [:]
-    for (k, v) in headersDict { mergedHeaders[k] = String(describing: v) }
-    for (k, v) in tokens.headers { mergedHeaders[k] = v }
-    mergedHeaders["prefetchKey"] = prefetchKey
+    for (k, v) in headersDict { mergedHeaders[k.lowercased()] = String(describing: v) }
+    for (k, v) in tokens.headers { mergedHeaders[k.lowercased()] = v }
+    mergedHeaders["prefetchkey"] = prefetchKey
     let headers = mergedHeaders.map { NitroHeader(key: $0.key, value: $0.value) }
 
     let methodStr = entry["method"] as? String
@@ -371,12 +372,7 @@ public final class NitroAutoPrefetcher: NSObject {
         guard let header = comp["header"] as? String,
               let template = comp["template"] as? String,
               let paths = comp["paths"] as? [String: String] else { continue }
-        var built = template
-        for (ph, jsonPath) in paths {
-          let val = getNestedField(json, dotPath: jsonPath) ?? ""
-          built = built.replacingOccurrences(of: "{{\(ph)}}", with: val)
-        }
-        headers[header] = built
+        headers[header] = applyCompositeTemplate(template, paths: paths, json: json)
       }
     }
 
@@ -402,15 +398,39 @@ public final class NitroAutoPrefetcher: NSObject {
   }
 
   private static func getNestedField(_ obj: [String: Any], dotPath: String) -> String? {
-    let parts = dotPath.split(separator: ".").map(String.init)
+    let parts = dotPath.components(separatedBy: ".")
     var current: Any = obj
     for part in parts {
-      guard let dict = current as? [String: Any],
-            let next = dict[part] else { return nil }
-      current = next
+      if let dict = current as? [String: Any], let next = dict[part] {
+        current = next
+      } else if let array = current as? [Any], let index = Int(part),
+                index >= 0, index < array.count, String(index) == part {
+        current = array[index]
+      } else {
+        return nil
+      }
     }
+    if current is NSNull { return nil }
     if let s = current as? String { return s }
+    if let number = current as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
+      return number.boolValue ? "true" : "false"
+    }
     return String(describing: current)
+  }
+
+  private static let compositeTemplatePattern = try! NSRegularExpression(pattern: "\\{\\{([^{}]+)\\}\\}")
+
+  private static func applyCompositeTemplate(_ template: String, paths: [String: String], json: [String: Any]) -> String {
+    let source = template as NSString
+    let result = NSMutableString(string: template)
+    let matches = compositeTemplatePattern.matches(in: template, range: NSRange(location: 0, length: source.length))
+    // Match the original text once; replacements cannot become new placeholders.
+    for match in matches.reversed() {
+      let placeholder = source.substring(with: match.range(at: 1))
+      guard let path = paths[placeholder] else { continue }
+      result.replaceCharacters(in: match.range, with: getNestedField(json, dotPath: path) ?? "")
+    }
+    return result as String
   }
 
   private static func setNestedField(_ root: inout [String: Any], dotPath: String, value: String) {

--- a/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
+++ b/packages/react-native-nitro-websockets/android/src/main/java/com/margelo/nitro/nitrofetchwebsockets/NitroWebSocketAutoPrewarmer.kt
@@ -212,10 +212,10 @@ object NitroWebSocketAutoPrewarmer {
       val headersObj = obj.optJSONObject("headers")
       if (headersObj != null) {
         headersObj.keys().forEachRemaining { k ->
-          merged[k] = headersObj.optString(k, "")
+          merged[k.lowercase()] = headersObj.optString(k, "")
         }
       }
-      tokenHeaders.forEach { (k, v) -> merged[k] = v }
+      tokenHeaders.forEach { (k, v) -> merged[k.lowercase()] = v }
 
       NitroLogger.d("NitroWS", "[TokenRefresh] Pre-warming $url with ${merged.size} header(s)")
       merged.forEach { (k, v) -> NitroLogger.d("NitroWS", "[TokenRefresh]   $k: $v") }
@@ -276,7 +276,8 @@ object NitroWebSocketAutoPrewarmer {
     }
 
     // JSON
-    val json = try { JSONObject(body) } catch (_: Throwable) { return result }
+    // Let the caller apply onFailure instead of caching an empty success.
+    val json = JSONObject(body)
 
     val mappings = config.optJSONArray("mappings")
     if (mappings != null) {
@@ -297,12 +298,7 @@ object NitroWebSocketAutoPrewarmer {
         val header = comp.optStringOrNull("header") ?: continue
         val template = comp.optStringOrNull("template") ?: continue
         val paths = comp.optJSONObject("paths") ?: continue
-        var built = template
-        paths.keys().forEachRemaining { ph ->
-          val val2 = getNestedField(json, paths.optString(ph, ""))
-          built = built.replace("{{$ph}}", val2 ?: "")
-        }
-        result[header] = built
+        result[header] = applyCompositeTemplate(template, paths, json)
       }
     }
 
@@ -313,9 +309,21 @@ object NitroWebSocketAutoPrewarmer {
     val parts = dotPath.split(".")
     var current: Any = obj
     for (part in parts) {
-      if (current !is JSONObject) return null
-      current = current.opt(part) ?: return null
+      current = when (val value = current) {
+        is JSONObject -> value.opt(part)
+        is JSONArray -> part.toIntOrNull()?.takeIf { it >= 0 && it.toString() == part }?.let { value.opt(it) }
+        else -> null
+      } ?: return null
     }
+    if (current === JSONObject.NULL) return null
     return current.toString()
   }
+
+  private val compositeTemplatePattern = Regex("\\{\\{([^{}]+)\\}\\}")
+
+  private fun applyCompositeTemplate(template: String, paths: JSONObject, json: JSONObject): String =
+    compositeTemplatePattern.replace(template) { match ->
+      val placeholder = match.groupValues[1]
+      if (paths.has(placeholder)) getNestedField(json, paths.optString(placeholder, "")) ?: "" else match.value
+    }
 }

--- a/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
+++ b/packages/react-native-nitro-websockets/ios/NitroWSAutoBootstrap.mm
@@ -31,12 +31,44 @@ static NSString* NitroWSGetNestedField(NSDictionary *dict, NSString *dotPath) {
   NSArray<NSString *> *parts = [dotPath componentsSeparatedByString:@"."];
   id current = dict;
   for (NSString *part in parts) {
-    if (![current isKindOfClass:[NSDictionary class]]) return nil;
-    current = ((NSDictionary *)current)[part];
+    if ([current isKindOfClass:[NSDictionary class]]) {
+      current = ((NSDictionary *)current)[part];
+    } else if ([current isKindOfClass:[NSArray class]]) {
+      NSInteger index = part.integerValue;
+      if (index < 0 || (NSUInteger)index >= [current count] ||
+          ![[NSString stringWithFormat:@"%ld", (long)index] isEqualToString:part]) return nil;
+      current = ((NSArray *)current)[(NSUInteger)index];
+    } else {
+      return nil;
+    }
   }
-  if (current == nil) return nil;
+  if (current == nil || current == NSNull.null) return nil;
   if ([current isKindOfClass:[NSString class]]) return current;
+  if ([current isKindOfClass:[NSNumber class]] &&
+      CFGetTypeID((__bridge CFTypeRef)current) == CFBooleanGetTypeID()) {
+    return [current boolValue] ? @"true" : @"false";
+  }
   return [NSString stringWithFormat:@"%@", current];
+}
+
+static NSString* NitroWSApplyCompositeTemplate(NSString *templateString,
+                                              NSDictionary *paths,
+                                              NSDictionary *json) {
+  static NSRegularExpression *pattern;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    pattern = [NSRegularExpression regularExpressionWithPattern:@"\\{\\{([^{}]+)\\}\\}" options:0 error:nil];
+  });
+  NSMutableString *result = [templateString mutableCopy];
+  NSArray<NSTextCheckingResult *> *matches = [pattern matchesInString:templateString options:0 range:NSMakeRange(0, templateString.length)];
+  for (NSTextCheckingResult *match in matches.reverseObjectEnumerator) {
+    NSString *placeholder = [templateString substringWithRange:[match rangeAtIndex:1]];
+    NSString *path = paths[placeholder];
+    if (![path isKindOfClass:[NSString class]]) continue;
+    NSString *value = NitroWSGetNestedField(json, path) ?: @"";
+    [result replaceCharactersInRange:match.range withString:value];
+  }
+  return result;
 }
 
 /// Synchronous token refresh using NSURLSession + semaphore.
@@ -134,16 +166,7 @@ static NSDictionary<NSString*, NSString*>* NitroWSCallTokenRefreshSync(NSDiction
       if (![header isKindOfClass:[NSString class]] ||
           ![templ isKindOfClass:[NSString class]] ||
           ![paths isKindOfClass:[NSDictionary class]]) continue;
-      NSMutableString *built = [templ mutableCopy];
-      [paths enumerateKeysAndObjectsUsingBlock:^(NSString *ph, NSString *jsonPath, BOOL *stop) {
-        if (![ph isKindOfClass:[NSString class]] || ![jsonPath isKindOfClass:[NSString class]]) return;
-        NSString *val = NitroWSGetNestedField(json, jsonPath) ?: @"";
-        [built replaceOccurrencesOfString:[NSString stringWithFormat:@"{{%@}}", ph]
-                               withString:val
-                                  options:0
-                                    range:NSMakeRange(0, built.length)];
-      }];
-      result[header] = [built copy];
+      result[header] = NitroWSApplyCompositeTemplate(templ, paths, json);
     }
   }
 
@@ -192,12 +215,12 @@ static void NitroWSRunPrewarmsWithTokenHeaders(NSArray *arr,
     if ([staticHeaders isKindOfClass:[NSDictionary class]]) {
       [staticHeaders enumerateKeysAndObjectsUsingBlock:^(id k, id v, BOOL *stop) {
         if ([k isKindOfClass:[NSString class]]) {
-          headers[[k UTF8String]] = [[NSString stringWithFormat:@"%@", v] UTF8String];
+          headers[[[k lowercaseString] UTF8String]] = [[NSString stringWithFormat:@"%@", v] UTF8String];
         }
       }];
     }
     [tokenHeaders enumerateKeysAndObjectsUsingBlock:^(NSString *k, NSString *v, BOOL *stop) {
-      headers[[k UTF8String]] = [v UTF8String];
+      headers[[k.lowercaseString UTF8String]] = [v UTF8String];
     }];
 
     NitroWSLog(@"[NitroWS] Pre-warming %@ with %zu header(s)", url, headers.size());


### PR DESCRIPTION
## Fixes

- Refreshed headers override stored headers case-insensitively in Fetch and WebSocket bootstrap; internal prefetch keys override every casing variant.
- Read nested array paths, omit JSON null values, preserve empty path segments and format Apple booleans consistently with JS.
- Treat malformed Android JSON as refresh failure so the configured onFailure policy runs instead of caching an empty success.
- Replace composite placeholders from the original template once; inserted token values cannot be expanded again. Cache compiled patterns and preserve unknown placeholders.

## Compatibility / breaking changes

- Bootstrap merge keys are normalized to lowercase. Conflicting case variants no longer produce duplicate headers.
- JSON null no longer becomes a literal header value; Apple booleans become true/false instead of 1/0. Nested array and empty-key paths now resolve.
- Malformed Android JSON now invokes the existing skip/useStoredHeaders policy. Missing configured composite values still become empty; unknown placeholders remain literal.
- No token-cache schema, secure-storage format, dependency or release version changes. These fixes do not include the separate logging/key-initialization PRs.

## Verification

- Actual extracted Swift/Kotlin/ObjC++ mapping and merge code: 41 passing cases (20/30 Swift/Kotlin assertions fail on the baseline; ObjC baseline also reproduces failures). Includes null/boolean/array/invalid-index controls, literal cross-referencing tokens, Unicode/dollar values, missing/unknown placeholders and unrelated-header preservation.
- Both complete native examples build: Android Debug and iOS Release, with tracing enabled. Existing JS/package checks remain passing on the combined candidate.
- Diagnostic harnesses are external; no test/spec files are added or modified. Physical device cold-start integration is not claimed.

Fixes #216. Fixes #217. Fixes #218.

### Consumer follow-up verification

The combined fixes are backported to an immutable 1.6.1 artifact. Both consuming app Android Debug variants, both iOS Debug Simulator variants, four production Metro bundles, 13 web targets, four browser-extension builds, lint and immutable installation pass. All 274 installed non-metadata files match the artifact. This is build verification, not a physical-device authentication/upload certification.
