### PR TITLE
fix: await startup token refresh for late iOS prefetches

### DIFF
--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/AutoPrefetcher.kt
@@ -2,6 +2,7 @@ package com.margelo.nitro.nitrofetch
 
 import android.app.Application
 import android.content.Context
+import android.content.SharedPreferences
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.HttpURLConnection
@@ -12,6 +13,10 @@ import java.util.concurrent.Executors
 
 object AutoPrefetcher {
   @Volatile private var initialized = false
+  // Startup token-refresh outcome, resolved at most once per process. Once
+  // resolved, null tokens mean the refresh failed with onFailure=skip.
+  @Volatile private var tokenRefreshResolved = false
+  @Volatile private var tokenRefreshTokens: TokenRefreshResult? = null
   // Serializes queue reads/writes and keeps Keystore work off the caller (main) thread.
   private val executor = Executors.newSingleThreadExecutor { r -> Thread(r, "NitroAutoPrefetch") }
   private const val KEY_QUEUE = "nitrofetch_autoprefetch_queue"
@@ -67,10 +72,14 @@ object AutoPrefetcher {
         NitroFetchSecureAtRest.putEncrypted(prefs, KEY_QUEUE, next.toString())
 
         if (initialized) {
-          // late path — kick a single immediate prefetch with cached tokens
-          val tokens = deserializeCache(NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_CACHE))
-          val single = JSONArray().apply { put(entry) }
-          startPrefetches(single, tokens)
+          // late path — share the startup refresh, including its skip decision
+          val tokens = lateRegistrationTokens(prefs)
+          if (tokens != null) {
+            val single = JSONArray().apply { put(entry) }
+            startPrefetches(single, tokens)
+          } else {
+            NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping late prefetch $prefetchKey")
+          }
         }
       } catch (_: Throwable) {
         // best-effort
@@ -95,39 +104,7 @@ object AutoPrefetcher {
       val refreshRaw = NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_REFRESH)
 
       if (!refreshRaw.isNullOrEmpty()) {
-        val refreshConfig = JSONObject(refreshRaw)
-        val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
-        val refreshURL = refreshConfig.optString("url", "(unknown)")
-        NitroLogger.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
-
-        val refreshed = callTokenRefreshSync(refreshConfig)
-
-        val tokens: TokenRefreshResult = if (refreshed != null) {
-          NitroLogger.d(
-            "NitroFetch",
-            "[TokenRefresh] ✅ Success — got ${refreshed.headers.size} header(s), " +
-              "${refreshed.bodyFields.size} body field(s), ${refreshed.formFields.size} form field(s)"
-          )
-          logTokens(refreshed)
-          // Cache fresh tokens for useStoredHeaders fallback on next cold start
-          NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
-          refreshed
-        } else {
-          NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
-          if (onFailure == "skip") {
-            NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
-            return
-          }
-          // Use last cached tokens (or empty if none cached yet)
-          val cached = deserializeCache(NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_CACHE))
-          NitroLogger.d(
-            "NitroFetch",
-            "[TokenRefresh] Using cached tokens (${cached.headers.size} header(s), " +
-              "${cached.bodyFields.size} body field(s), ${cached.formFields.size} form field(s))"
-          )
-          cached
-        }
-
+        val tokens = resolveTokenRefresh(prefs, refreshRaw) ?: return
         NitroLogger.d("NitroFetch", "[TokenRefresh] Injecting tokens into ${arr.length()} prefetch URL(s)")
         startPrefetches(arr, tokens)
       } else {
@@ -137,6 +114,75 @@ object AutoPrefetcher {
     } catch (_: Throwable) {
       // ignore – prefetch-on-start is best-effort, never crash the app
     }
+  }
+
+  /**
+   * Tokens a late registration should send with, or null when the startup
+   * refresh failed with onFailure=skip. Runs the refresh here only when an
+   * empty startup queue meant it never ran, so cold start pays nothing extra.
+   */
+  private fun lateRegistrationTokens(prefs: SharedPreferences): TokenRefreshResult? {
+    if (tokenRefreshResolved) return tokenRefreshTokens
+    val refreshRaw = NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_REFRESH)
+    if (refreshRaw.isNullOrEmpty()) {
+      return deserializeCache(NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_CACHE))
+    }
+    return resolveTokenRefresh(prefs, refreshRaw)
+  }
+
+  /** Runs the token refresh once per process. Null means onFailure=skip. */
+  private fun resolveTokenRefresh(
+    prefs: SharedPreferences,
+    refreshRaw: String,
+  ): TokenRefreshResult? {
+    if (tokenRefreshResolved) return tokenRefreshTokens
+
+    val refreshConfig = try { JSONObject(refreshRaw) } catch (_: Throwable) { null }
+    if (refreshConfig == null) {
+      tokenRefreshResolved = true
+      tokenRefreshTokens = TokenRefreshResult.EMPTY
+      return TokenRefreshResult.EMPTY
+    }
+    val onFailure = refreshConfig.optString("onFailure", "useStoredHeaders")
+    val refreshURL = refreshConfig.optString("url", "(unknown)")
+    NitroLogger.d("NitroFetch", "[TokenRefresh] Calling refresh endpoint: $refreshURL")
+
+    val refreshed = callTokenRefreshSync(refreshConfig)
+
+    val tokens: TokenRefreshResult? = if (refreshed != null) {
+      NitroLogger.d(
+        "NitroFetch",
+        "[TokenRefresh] ✅ Success — got ${refreshed.headers.size} header(s), " +
+          "${refreshed.bodyFields.size} body field(s), ${refreshed.formFields.size} form field(s)"
+      )
+      logTokens(refreshed)
+      // Cache fresh tokens for useStoredHeaders fallback on next cold start
+      try {
+        NitroFetchSecureAtRest.putEncrypted(prefs, KEY_TOKEN_CACHE, serializeCache(refreshed))
+      } catch (_: Throwable) {
+        // best-effort cache write
+      }
+      refreshed
+    } else {
+      NitroLogger.d("NitroFetch", "[TokenRefresh] ❌ Refresh failed — onFailure: $onFailure")
+      if (onFailure == "skip") {
+        NitroLogger.d("NitroFetch", "[TokenRefresh] Skipping all prefetches")
+        null
+      } else {
+        // Use last cached tokens (or empty if none cached yet)
+        val cached = deserializeCache(NitroFetchSecureAtRest.getDecryptedForPrefs(prefs, KEY_TOKEN_CACHE))
+        NitroLogger.d(
+          "NitroFetch",
+          "[TokenRefresh] Using cached tokens (${cached.headers.size} header(s), " +
+            "${cached.bodyFields.size} body field(s), ${cached.formFields.size} form field(s))"
+        )
+        cached
+      }
+    }
+
+    tokenRefreshResolved = true
+    tokenRefreshTokens = tokens
+    return tokens
   }
 
   private fun startPrefetches(arr: JSONArray, tokens: TokenRefreshResult) {

--- a/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
+++ b/packages/react-native-nitro-fetch/ios/NitroAutoPrefetcher.swift
@@ -3,6 +3,7 @@ import Foundation
 @objc(NitroAutoPrefetcher)
 public final class NitroAutoPrefetcher: NSObject {
   private static var initialized = false
+  private static var tokenRefreshTask: Task<TokenRefreshResult?, Never>?
   // Serializes queue reads/writes and keeps Keychain work off the launch thread.
   private static let workQueue = DispatchQueue(label: "com.margelo.nitrofetch.autoprefetch")
   private static let queueKey = "nitrofetch_autoprefetch_queue"
@@ -115,10 +116,19 @@ public final class NitroAutoPrefetcher: NSObject {
       }
 
       if initialized {
-        // Late path — apply cached tokens + kick immediate prefetch
-        let tokens = deserializeCache(
-          NitroFetchSecureAtRest.decryptedString(forKey: tokenCacheKey, defaults: userDefaults))
-        startPrefetches([entry], tokens: tokens)
+        // Share the startup refresh, including its skip/fallback decision.
+        let refreshTask = tokenRefreshTask
+        Task {
+          let tokens: TokenRefreshResult
+          if let refreshTask = refreshTask {
+            guard let refreshed = await refreshTask.value else { return }
+            tokens = refreshed
+          } else {
+            tokens = deserializeCache(
+              NitroFetchSecureAtRest.decryptedString(forKey: tokenCacheKey, defaults: userDefaults))
+          }
+          startPrefetches([entry], tokens: tokens)
+        }
       }
     }
   }
@@ -142,7 +152,7 @@ public final class NitroAutoPrefetcher: NSObject {
   }
 
   private static func runTokenRefreshAndPrefetch(arr: [Any], refreshRaw: String?, userDefaults: UserDefaults) {
-    Task {
+    tokenRefreshTask = Task {
       // Resolve tokens (may require a network call)
       let tokens: TokenRefreshResult
       if let refreshRaw = refreshRaw,
@@ -165,7 +175,7 @@ public final class NitroAutoPrefetcher: NSObject {
           NitroLogger.log("[NitroFetch][TokenRefresh] ❌ Refresh failed — onFailure: \(onFailure)")
           if onFailure == "skip" {
             NitroLogger.log("[NitroFetch][TokenRefresh] Skipping all prefetches")
-            return
+            return nil
           }
           let cached = deserializeCache(
             NitroFetchSecureAtRest.decryptedString(forKey: tokenCacheKey, defaults: userDefaults))
@@ -177,6 +187,7 @@ public final class NitroAutoPrefetcher: NSObject {
       }
 
       startPrefetches(arr, tokens: tokens)
+      return tokens
     }
   }
 


### PR DESCRIPTION
## Fixes

Late iOS registrations share the existing startup token-refresh task rather than sending immediately with old cached credentials. They honor success, stored-token fallback, and skip. This keeps network work asynchronous and adds no refresh requests.

## Compatibility / breaking changes

Late requests now wait for the in-flight refresh; onFailure=skip suppresses them when refresh fails. Previously they could already have been sent. Registrations when startup has no refresh task retain cached-token fallback. No public API or persisted schema changes.

## Verification

Three gated Swift reproductions execute the actual registration/startup methods: success, skip, and stored-token fallback all fail on baseline and pass after the fix. Synthetic tokens only, no network. The iOS Release example builds with tracing enabled. No test/spec files changed; physical-device cold-start testing is not claimed.

Fixes #222.

### Consumer follow-up verification

The combined fixes are backported to an immutable 1.6.1 artifact. Both consuming app Android Debug variants, both iOS Debug Simulator variants, four production Metro bundles, 13 web targets, four browser-extension builds, lint and immutable installation pass. All 274 installed non-metadata files match the artifact. This is build verification, not a physical-device authentication/upload certification.
