### PR TITLE
fix: encode native multipart names and line breaks correctly

### DIFF
--- a/docs-website/docs/form-data.md
+++ b/docs-website/docs/form-data.md
@@ -44,3 +44,5 @@ const res = await fetch('https://httpbin.org/post', {
 :::note
 The `FormData` API follows the standard browser interface. File objects use the React Native convention with `uri`, `type`, and `name` fields.
 :::
+
+Native multipart serialization escapes quotes and line breaks in field names and filenames. Field names and string values normalize line breaks to CRLF; file bytes are unchanged. Repeated fields retain their order. File MIME types containing CR or LF reject the request instead of creating malformed multipart headers. Uploads are still buffered in memory; these encoding rules do not add streaming file uploads.

--- a/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
+++ b/packages/react-native-nitro-fetch/android/src/main/java/com/margelo/nitro/nitrofetch/HybridNitroFetchClient.kt
@@ -361,19 +361,23 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
 
       for (part in parts) {
         out.write("--$boundary\r\n".toByteArray())
+        val name = escapeMultipartParameter(normalizeMultipartLineBreaks(part.name))
 
         val fileUri = part.fileUri
         if (fileUri != null) {
-          val fileName = part.fileName ?: "file"
+          val fileName = escapeMultipartParameter(part.fileName ?: "file")
           val mimeType = part.mimeType ?: "application/octet-stream"
-          out.write("Content-Disposition: form-data; name=\"${part.name}\"; filename=\"$fileName\"\r\n".toByteArray())
+          require(!mimeType.contains('\r') && !mimeType.contains('\n')) {
+            "Multipart MIME type must not contain line breaks"
+          }
+          out.write("Content-Disposition: form-data; name=\"$name\"; filename=\"$fileName\"\r\n".toByteArray())
           out.write("Content-Type: $mimeType\r\n\r\n".toByteArray())
 
           val fileData = readFileBytes(fileUri)
           out.write(fileData)
         } else {
-          val value = part.value ?: ""
-          out.write("Content-Disposition: form-data; name=\"${part.name}\"\r\n\r\n".toByteArray())
+          val value = normalizeMultipartLineBreaks(part.value ?: "")
+          out.write("Content-Disposition: form-data; name=\"$name\"\r\n\r\n".toByteArray())
           out.write(value.toByteArray(Charsets.UTF_8))
         }
 
@@ -382,6 +386,14 @@ class HybridNitroFetchClient(private val engine: CronetEngine, private val execu
 
       out.write("--$boundary--\r\n".toByteArray())
       return Pair(out.toByteArray(), "multipart/form-data; boundary=$boundary")
+    }
+
+    private fun normalizeMultipartLineBreaks(value: String): String {
+      return value.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
+    }
+
+    private fun escapeMultipartParameter(value: String): String {
+      return value.replace("\r", "%0D").replace("\n", "%0A").replace("\"", "%22")
     }
 
     private fun readFileBytes(uri: String): ByteArray {

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -371,18 +371,23 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
 
     for part in parts {
       body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+      let name = escapeMultipartParameter(normalizeMultipartLineBreaks(part.name))
 
       if let fileUri = part.fileUri {
-        let fileName = part.fileName ?? "file"
+        let fileName = escapeMultipartParameter(part.fileName ?? "file")
         let mimeType = part.mimeType ?? "application/octet-stream"
-        body.append("Content-Disposition: form-data; name=\"\(part.name)\"; filename=\"\(fileName)\"\(crlf)".data(using: .utf8)!)
+        guard !mimeType.contains("\r"), !mimeType.contains("\n") else {
+          throw NSError(domain: "NitroFetch", code: -5,
+                        userInfo: [NSLocalizedDescriptionKey: "Multipart MIME type must not contain line breaks"])
+        }
+        body.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(fileName)\"\(crlf)".data(using: .utf8)!)
         body.append("Content-Type: \(mimeType)\(crlf)\(crlf)".data(using: .utf8)!)
 
         let fileData = try await readFileData(fileUri)
         body.append(fileData)
       } else {
-        let value = part.value ?? ""
-        body.append("Content-Disposition: form-data; name=\"\(part.name)\"\(crlf)\(crlf)".data(using: .utf8)!)
+        let value = normalizeMultipartLineBreaks(part.value ?? "")
+        body.append("Content-Disposition: form-data; name=\"\(name)\"\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(value.data(using: .utf8)!)
       }
 
@@ -391,6 +396,18 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
 
     body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
     return (body, "multipart/form-data; boundary=\(boundary)")
+  }
+
+  private static func normalizeMultipartLineBreaks(_ value: String) -> String {
+    return value.replacingOccurrences(of: "\r\n", with: "\n")
+      .replacingOccurrences(of: "\r", with: "\n")
+      .replacingOccurrences(of: "\n", with: "\r\n")
+  }
+
+  private static func escapeMultipartParameter(_ value: String) -> String {
+    return value.replacingOccurrences(of: "\r", with: "%0D")
+      .replacingOccurrences(of: "\n", with: "%0A")
+      .replacingOccurrences(of: "\"", with: "%22")
   }
 
   private static func readFileData(_ uri: String) async throws -> Data {


### PR DESCRIPTION
## Fixes

- Escape quotes/CR/LF in native multipart field names and filenames.
- Normalize field-name and string-value line endings to CRLF without modifying file bytes.
- Reject file MIME types containing CR/LF before uploading malformed multipart headers.
- Preserve field order, duplicate fields, Unicode, literal percent/backslash values, empty filenames and file metadata defaults.

## Compatibility / breaking changes

Names and text values containing line breaks now use browser-compatible multipart encoding; quotes in parameters become percent-encoded. Invalid multiline MIME types now reject. File bytes, public signatures, buffer strategy and dependency versions are unchanged. This does not implement streaming uploads or bound upload memory.

## Verification

24 external native serialization checks pass, executing the actual Swift/Kotlin serializers and comparing bytes with Node FormData (except retaining the existing explicit empty filename, which Node omits). 12 assertions fail on the original source. Both native examples build with tracing enabled; no physical device/network upload claim. No test/spec files changed.

Algorithm reference: [HTML multipart encoding](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data).

Fixes #224.

### Consumer follow-up verification

The combined fixes are backported to an immutable 1.6.1 artifact. Both consuming app Android Debug variants, both iOS Debug Simulator variants, four production Metro bundles, 13 web targets, four browser-extension builds, lint and immutable installation pass. All 274 installed non-metadata files match the artifact. This is build verification, not a physical-device authentication/upload certification.
