### PR TITLE
fix(text-decoder): use concrete web-streams-polyfill path so Metro can resolve it (#103 follow-up)

### DIFF
--- a/packages/react-native-nitro-text-decoder/src/TextDecoder.ts
+++ b/packages/react-native-nitro-text-decoder/src/TextDecoder.ts
@@ -1,4 +1,5 @@
-import 'web-streams-polyfill/polyfill'
+// Concrete path so Metro resolves it even with unstable_enablePackageExports: false (#103).
+import 'web-streams-polyfill/dist/polyfill.js'
 import { NitroModules } from 'react-native-nitro-modules'
 import type {
   NitroTextDecoder,


### PR DESCRIPTION
Follow-up to #103, which was closed as completed but only fixed one of the two packages.

### What's still broken

`react-native-nitro-fetch/src/fetch.ts` was changed to use a concrete path:

```ts
// Concrete path so Metro resolves it even with unstable_enablePackageExports: false (#103).
import 'web-streams-polyfill/dist/polyfill.js';
```

but `react-native-nitro-text-decoder/src/TextDecoder.ts` still has the original form:

```ts
import 'web-streams-polyfill/polyfill'
```

`web-streams-polyfill@4` exposes `./polyfill` **only** through its `exports` map — there is no `polyfill.js` or `polyfill/` directory at the package root. So with `resolver.unstable_enablePackageExports = false` in `metro.config.js`, Metro falls back to filesystem resolution, looks for `node_modules/web-streams-polyfill/polyfill`, finds nothing, and the bundle fails with:

```
Unable to resolve "web-streams-polyfill/polyfill" from "node_modules/react-native-nitro-text-decoder/src/TextDecoder.ts"
```

Same root cause as #103, same failure, just the package that got missed. Anyone depending on `react-native-nitro-text-decoder` with package exports disabled still can't bundle.

### Change

One line, applying the identical fix (and the same explanatory comment) that `fetch.ts` already carries.

### One thing worth your judgement

Unlike `fetch.ts`, this package appears not to reference any stream class at all — the only match for `Stream` in `packages/react-native-nitro-text-decoder/src` is that import line itself, and the `stream` in `TextDecoder.nitro.ts` is the `TextDecodeOptions.stream` boolean, not a stream object. If that's right, the import could be **deleted** rather than repointed, which would also avoid unconditionally installing 13 global stream classes on consumers who only wanted a text decoder.

I went with the conservative fix here because it matches what you already did in `fetch.ts` and can't change runtime behaviour. Happy to switch this PR to a straight removal if you'd prefer that — your call, you know whether anything downstream leans on the side effect.

### Testing

Not built locally — I don't have a Nitrogen/example-app setup for this repo. The change is a one-line import path, identical to the one already merged in `fetch.ts`, and the target file `node_modules/web-streams-polyfill/dist/polyfill.js` is a real file in the published package. For context, we run the equivalent change (as a full removal) as a local patch over `react-native-nitro-text-decoder@0.2.0`, which is what surfaced this.
