### PR TITLE
fix: reject a buffered response when the request was aborted in flight

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -531,6 +531,30 @@ describe('NitroFetch - AbortController', () => {
     expect(elapsed).toBeLessThan(5000);
   });
 
+  it('abort after the response is buffered still rejects', async () => {
+    const controller = new AbortController();
+    const pending = nitroFetch(`${BASE}/get`, { signal: controller.signal });
+
+    // Block the JS thread so native finishes while the continuation cannot run,
+    // then abort inside that window — cancel() is already a no-op by then.
+    const until = Date.now() + 1500;
+    let spins = 0;
+    while (Date.now() < until) {
+      spins += 1;
+    }
+    expect(spins).toBeGreaterThan(0);
+    controller.abort();
+
+    let threw = false;
+    try {
+      await pending;
+    } catch (e: any) {
+      threw = true;
+      expect(e.name).toBe('AbortError');
+    }
+    expect(threw).toBe(true);
+  });
+
   it('normal fetch with signal (not aborted) succeeds', async () => {
     const controller = new AbortController();
     const res = await nitroFetch(`${BASE}/get`, {

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -734,6 +734,11 @@ async function nitroFetchRaw(
 
   try {
     const res: NitroResponseNative = await client.request(req);
+    // Native cancellation is best-effort — cancel() is a no-op once the
+    // response is buffered, so an aborted request can still resolve here.
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
     if (inspectorId) {
       NetworkInspector._recordEnd(
         inspectorId,


### PR DESCRIPTION
Closes #232.

## Problem

`fetch()` can resolve as a normal success after its `AbortSignal` has fired. Cronet's `UrlRequest.cancel()` and `URLSessionTask.cancel()` are best-effort and are documented no-ops once the request has completed, so when the cancel loses that race `nitroFetchRaw` hands back a response the caller has already abandoned — which then goes on to parse a body it discarded. `nitroStreamFetch` already checks `signal?.aborted` in several places; only the buffered path is missing it.

Full diagnosis and the device measurement are in #232. In short: on a Fire TV stick, 4 of 4 superseded search requests completed and were JSON-parsed with `signal.aborted === true`; with this change, 0 of 4.

## Fix

```diff
  const res: NitroResponseNative = await client.request(req);
+ if (signal?.aborted) {
+   throw createAbortError();
+ }
```

Placed before `NetworkInspector._recordEnd` so an aborted request falls into the existing `catch` and is recorded as aborted, rather than as a 200 the caller never received.

The existing `abort mid-flight cancels a slow request` harness case passes without this change — aborting 100 ms into `/delay/20` lets the native cancel win comfortably — so it never covered the window where the response is already buffered. Added a case alongside it that blocks the JS thread to hold that window open.

## Testing

- `bun test` — 10 pass, 2 existing todos, 0 fail
- `bun typecheck` — clean
- `eslint "**/*.{js,ts,tsx}"` — 0 errors, the 2 existing `no-shadow` warnings in the Expo plugin files. Run under node; `bun lint` hits an unrelated `structuredClone is not defined` in `@eslint/config-array` on macOS that CI on Linux does not
- `tsc --noEmit` in `example/` — the new harness case adds no errors; the 4 in that file are identical to those on `main`
- The new harness case itself is **not run** — `test:harness` needs the example app built onto a device, which I have not done
