### PR TITLE
fix(ios): detect CRLF in multipart MIME types, and correct the filename test

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -260,9 +260,10 @@ describe('NitroFetch - Request Body Types', () => {
     expect(body.form.multiline).toBe('line1\r\nline2');
   });
 
-  // The server percent-decodes filename (but not name), so an escaped filename
-  // round-trips; an unescaped quote truncates it at the quote instead.
-  it('FormData filename with a quote survives the round trip', async () => {
+  // Per the WHATWG multipart/form-data algorithm a quote is escaped as %22 and
+  // must not be further escaped; receivers do not decode it. So the server sees
+  // the literal %22 — an unescaped quote would make it drop the part entirely.
+  it('FormData filename with a quote is percent-escaped on the wire', async () => {
     const fd = new FormData();
     fd.append('photo', {
       uri: image,
@@ -271,7 +272,7 @@ describe('NitroFetch - Request Body Types', () => {
     } as any);
     const res = await nitroFetch(`${BASE}/post`, { method: 'POST', body: fd });
     const body = await res.json();
-    expect(body.fileNames.photo).toBe('na"me.jpg');
+    expect(body.fileNames.photo).toBe('na%22me.jpg');
   });
 
   it('FormData file MIME type with a line break rejects', async () => {

--- a/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
+++ b/packages/react-native-nitro-fetch/ios/HybridNitroFetchClient.swift
@@ -376,7 +376,10 @@ final class HybridNitroFetchClient: HybridNitroFetchClientSpec {
       if let fileUri = part.fileUri {
         let fileName = escapeMultipartParameter(part.fileName ?? "file")
         let mimeType = part.mimeType ?? "application/octet-stream"
-        guard !mimeType.contains("\r"), !mimeType.contains("\n") else {
+        // String.contains(_:) matches grapheme clusters, and CRLF is a single
+        // cluster — so contains("\r") is false for "a\r\nb", the exact shape a
+        // header-injection payload takes. Scan unicode scalars instead.
+        guard !mimeType.unicodeScalars.contains(where: { $0 == "\r" || $0 == "\n" }) else {
           throw NSError(domain: "NitroFetch", code: -5,
                         userInfo: [NSLocalizedDescriptionKey: "Multipart MIME type must not contain line breaks"])
         }


### PR DESCRIPTION
Fixes the two red harness jobs on `main`. They have been failing since #229 landed, and they turned out to be two unrelated defects that happened to surface together.

## 1. iOS never rejected a CRLF in a multipart MIME type

#229 added a guard meant to stop header injection through a file's `type`:

```swift
guard !mimeType.contains("\r"), !mimeType.contains("\n") else { throw ... }
```

`String.contains(_:)` compares **grapheme clusters**, and CRLF is a single cluster. So for the one payload shape that matters:

```swift
"image/jpeg\r\nX-Injected: 1".contains("\r")   // false
"image/jpeg\r\nX-Injected: 1".contains("\n")   // false
"image/jpeg\r\nX-Injected: 1".contains("\r\n") // true
```

Neither guard fired, and iOS wrote the attacker-controlled bytes straight into the part headers. A lone CR or LF *was* caught, which is why only the CRLF case slipped through. Against the harness server, what iOS sends today parses as a clean upload with a smuggled header:

```
Content-Disposition: form-data; name="photo"; filename="test.jpg"
Content-Type: image/jpeg
X-Injected: 1          <- attacker-controlled, accepted as a real part header
```

Scanning unicode scalars instead catches all three forms. Android was never affected — it passes a `Char` to `contains`, which is a plain UTF-16 scan.

## 2. The filename test asserted something no server does

`FormData filename with a quote survives the round trip` expected the server to hand back `na"me.jpg`, on the premise that it percent-decodes filenames. busboy 1.6.0 does not, so **both** platforms returned the literal `na%22me.jpg` and both jobs failed.

The encoder is right and the expectation was wrong. The WHATWG multipart/form-data algorithm requires `"` to be escaped as `%22` and says the UA "must not perform any other escapes"; receivers are not meant to decode it. Verified against the harness server:

| sent on the wire | server reports |
| --- | --- |
| `filename="na%22me.jpg"` | `na%22me.jpg` |
| `filename="na\"me.jpg"` | `na"me.jpg` (backslash escaping — not what the spec asks for) |
| `filename="na"me.jpg"` | part dropped entirely |

So the test now asserts the `%22` that actually goes over the wire, and the misleading comment is replaced. Renamed to `FormData filename with a quote is percent-escaped on the wire`, since it is testing the encoding, not a round trip.

## Testing

Full iOS harness run locally against a real simulator, with the app built from this branch.

```
Test Suites: 9 passed, 9 total
Tests:       267 passed, 267 total
```

Both previously failing cases now pass, and the `FormData file MIME type with a line break rejects` case is a real regression test for the guard — it uses the CRLF shape, the only one the old check missed.