### PR TITLE
fix: settle a streamed fetch when a late abort loses the cancel race

### DIFF
--- a/example/__tests__/nitrofetch.harness.ts
+++ b/example/__tests__/nitrofetch.harness.ts
@@ -647,6 +647,40 @@ describe('NitroFetch - Streaming', () => {
     expect(threw).toBe(true);
   });
 
+  it('aborting while the response callback is queued still settles', async () => {
+    const controller = new AbortController();
+    // /delay/1 so the request is definitely in flight before the JS thread is
+    // blocked — nitroStreamFetch only calls start() after two awaits, so
+    // blocking immediately would just hit the pre-flight abort check instead.
+    const pending = (nitroFetch as any)(`${BASE}/delay/1`, {
+      stream: true,
+      signal: controller.signal,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Now block long enough for the response to arrive and the request to
+    // complete natively, queueing onResponseStarted + onSucceeded behind the
+    // blocked thread. Aborting in that window makes cancel() a no-op.
+    const until = Date.now() + 2000;
+    let spins = 0;
+    while (Date.now() < until) {
+      spins += 1;
+    }
+    expect(spins).toBeGreaterThan(0);
+    controller.abort();
+
+    // A never-settling promise would hang the whole suite, so race a timeout
+    // and assert on the outcome instead.
+    const outcome = await Promise.race([
+      pending.then(
+        () => 'resolved',
+        (e: any) => e?.name ?? 'rejected'
+      ),
+      new Promise((r) => setTimeout(() => r('hung'), 3000)),
+    ]);
+    expect(outcome).toBe('AbortError');
+  });
+
   // The server drips for 10s. Polling stops the moment it records either
   // outcome, so a request that drains to completion fails fast rather than
   // burning the whole budget. Cronet can take a few seconds to close the

--- a/packages/react-native-nitro-fetch/src/fetch.ts
+++ b/packages/react-native-nitro-fetch/src/fetch.ts
@@ -841,8 +841,40 @@ async function nitroStreamFetch(
     let responseResolved = false;
     let streamBytesReceived = 0;
 
+    // A late abort can land after native has already delivered the response.
+    // cancel() is a documented no-op by then, so onCanceled never fires and
+    // these callbacks have to settle the promise themselves — otherwise the
+    // fetch hangs forever instead of rejecting.
+    let abortSettled = false;
+    const settleAborted = () => {
+      if (abortSettled) return;
+      abortSettled = true;
+      cleanupAbortListener();
+      if (inspectorId) {
+        NetworkInspector._recordEnd(
+          inspectorId,
+          0,
+          '',
+          [],
+          0,
+          'Request aborted'
+        );
+      }
+      const err = createAbortError();
+      if (!responseResolved) {
+        responseResolved = true;
+        rejectResponse(err);
+      } else {
+        streamController.error(err);
+      }
+    };
+
     builder.onResponseStarted((info) => {
-      if (responseResolved || signal?.aborted) return;
+      if (responseResolved) return;
+      if (signal?.aborted) {
+        settleAborted();
+        return;
+      }
       responseResolved = true;
       const status = info.httpStatusCode;
       const responseHeaders = new NitroHeaders(
@@ -877,6 +909,10 @@ async function nitroStreamFetch(
     builder.onSucceeded((_info) => {
       cleanupAbortListener();
       if (streamCancelled) return;
+      if (signal?.aborted) {
+        settleAborted();
+        return;
+      }
       streamController.close();
       if (inspectorId) {
         const info = _info as any;
@@ -935,8 +971,12 @@ async function nitroStreamFetch(
         try {
           request.cancel();
         } catch {
-          return;
+          // Request may already be torn down — swallow and settle anyway.
         }
+        // Settle here rather than waiting for onCanceled: once native has
+        // finished the request, cancel() is a no-op and no further callback
+        // arrives, which used to leave this promise pending forever.
+        settleAborted();
       };
       signal.addEventListener('abort', abortListener, { once: true });
     }


### PR DESCRIPTION
`fetch(url, { stream: true })` can hang forever instead of rejecting, when the `AbortSignal` fires after native has already finished the request.

## The hang

`cancel()` is a documented no-op once the request has completed, so when a late abort loses that race:

1. `onCanceled` never fires — there is nothing left to cancel.
2. `onResponseStarted` sees `signal.aborted` and returns early **without** calling `resolveResponse`, leaving `responseResolved === false`.
3. `onSucceeded` then runs with `streamCancelled === false`, closes the stream, and returns.

Nothing ever rejects the promise. It stays pending for the life of the app.

This is the streaming counterpart of the buffered-path bug in #231, but it fails silently rather than loudly: instead of handing back a response the caller abandoned, the `await` simply never returns.

## Fix

Settlement no longer depends on a native callback arriving at all. The abort listener settles directly after calling `cancel()`, via a shared idempotent helper that rejects the promise when the response has not resolved yet, and errors the body stream when it has. `onResponseStarted` and `onSucceeded` route through the same helper rather than returning silently.

That last part fixes a second, quieter problem: `onSucceeded` used to `close()` a body the caller had already abandoned, so a consumer aborting mid-stream saw a clean EOF where the spec wants an `AbortError`.

## Testing

Every existing abort test cancels early enough that `cancel()` wins, so none of them covered this window. The new case holds it open — it starts a request against `/delay/1`, waits until it is genuinely in flight (`nitroStreamFetch` only calls `start()` after two awaits, so blocking immediately would just hit the pre-flight check and prove nothing), then blocks the JS thread past completion and aborts inside that window. It races a 3s timeout so a regression fails the assertion instead of hanging the whole suite.

Verified on an iOS simulator, rebuilding the package each way:

| | result |
| --- | --- |
| without the fix | `expected 'hung' to be 'AbortError'` |
| with the fix | 6/6 abort tests pass |

Full suite on this branch is 267 passed / 1 failed — that one failure is the pre-existing multipart test that #233 fixes, unrelated to this change. **This should land after #233**, and its harness jobs will be green once rebased.