### PR TITLE
ci: retry harness e2e run up to 3 times

### DIFF
--- a/.github/workflows/harness-android.yml
+++ b/.github/workflows/harness-android.yml
@@ -176,7 +176,7 @@ jobs:
           # server holds the pipe open and the step hangs. Emulator reaches the
           # host via 10.0.2.2.
           script: |
-            (cd ../test-server && bun install --frozen-lockfile); bun ../test-server/server.mjs >/tmp/test-server.log 2>&1 </dev/null & SRV=$!; for i in $(seq 1 30); do curl -sf http://127.0.0.1:9876/get >/dev/null 2>&1 && break; sleep 1; done; curl -sf http://127.0.0.1:9876/get >/dev/null || { echo "test server failed to start"; cat /tmp/test-server.log; exit 1; }; adb install -r "./android/app/build/outputs/apk/debug/app-debug.apk"; bun run test:harness --harnessRunner android; ec=$?; kill $SRV 2>/dev/null || true; exit $ec
+            (cd ../test-server && bun install --frozen-lockfile); bun ../test-server/server.mjs >/tmp/test-server.log 2>&1 </dev/null & SRV=$!; for i in $(seq 1 30); do curl -sf http://127.0.0.1:9876/get >/dev/null 2>&1 && break; sleep 1; done; curl -sf http://127.0.0.1:9876/get >/dev/null || { echo "test server failed to start"; cat /tmp/test-server.log; exit 1; }; adb install -r "./android/app/build/outputs/apk/debug/app-debug.apk"; ec=1; for i in 1 2 3; do bun run test:harness --harnessRunner android && { ec=0; break; }; echo "harness attempt $i failed"; done; kill $SRV 2>/dev/null || true; exit $ec
 
       - name: Stop Gradle Daemon
         working-directory: example/android

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -173,4 +173,4 @@ jobs:
             sleep 1
           done
           curl -sf http://127.0.0.1:9876/get >/dev/null || { echo "test server failed to start"; exit 1; }
-          bun run test:harness --harnessRunner ios
+          ec=1; for i in 1 2 3; do bun run test:harness --harnessRunner ios && { ec=0; break; }; echo "harness attempt $i failed"; done; exit $ec


### PR DESCRIPTION
Currently iOS CI fails multiple times due to device responsive issues. I dont know why . Maybe cause its a mac OS small actiosn and not large . I will check but this is a patch fix for now . We retry like we do for core nightly tests